### PR TITLE
Change requirements to >=

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
        - To learn React, check out the [React documentation](https://reactjs.org/).
 
 3.  Setup dev environment for the backend
-    1. install `python 3.9.7` and create a venv or conda environment for this project
+    1. install `python` version >= 3.9.7 and create a venv or conda environment for this project
        - Official documents of connexion says `3.6` but tested on `3.9.7` seems to work fine.
     2. `npm run gen-api-code` to generate code for api layer (both server and client). Please remember to run this whenever open API definition changes.
     3. `pip install -r backend/src/gen/requirements.txt`

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -1,7 +1,7 @@
-connexion == 2.9.0
-python_dateutil == 2.6.0
+connexion >= 2.9.0
+python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 pymongo[srv]
 Flask-PyMongo
-swagger-ui-bundle == 0.0.9
+swagger-ui-bundle >= 0.0.9
 python-dotenv


### PR DESCRIPTION
Currently there are "==" requirements in the requirements file. I think it would probably be good not to force a specific version of a library as it precludes using newer versions. This can be an issue when there's a security-based fix for example, as this would prevent users from installing new, more-secure versions. I've run with the new version and it seems to be working.