### PR TITLE
feat(ui): add form for file type select

### DIFF
--- a/backend/src/impl/db_models/system_metadata_model.py
+++ b/backend/src/impl/db_models/system_metadata_model.py
@@ -144,7 +144,7 @@ class SystemOutputsModel(DBModel):
         filter: Dict[str, Any] = {}
         if output_ids:
             filter["id"] = {
-                "$in": [int(id) for id in output_ids.split(",")]
+                "$in": [str(id) for id in output_ids.split(",")]
             }
         cursor, total = super().find(filter)
         return SystemOutputsReturn([SystemOutputModel.from_dict(doc) for doc in cursor], total)

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -76,6 +76,9 @@ def systems_post(body: SystemsBody) -> SystemModel:
 
 
 def systems_system_id_outputs_get(system_id: str, output_ids: Optional[str]) -> SystemOutputsReturn:
+    """
+    TODO: return special error/warning if some ids cannot be found
+    """
     return SystemOutputsModel(system_id).find(output_ids)
 
 

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -5,5 +5,5 @@ pymongo[srv]
 Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
-explainaboard == 0.5.4
+explainaboard == 0.5.6
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -5,4 +5,5 @@ pymongo[srv]
 Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
-explainaboard == 0.5.3
+explainaboard == 0.5.4
+en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -5,4 +5,4 @@ pymongo[srv]
 Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
-explainaboard == 0.4.3
+explainaboard == 0.5.3

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -398,9 +398,8 @@ components:
       type: object
       properties:
         id:
-          type: integer
+          type: string
       additionalProperties: true
-
       required: [id]
 
     TaskMetadata:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -458,7 +458,6 @@ components:
           description: base64 encoded file
         file_type:
           type: string
-          enum: [tsv]
         task_output_type:
           type: string
           description: describes task-related system output format


### PR DESCRIPTION
✅ This PR depends on https://github.com/neulab/ExplainaBoard/pull/74 . This PR is ready to be merged now!
- Added a form item so users can select the file type. We can now generate analysis reports for NER (CoNLL format). related #54
![image](https://user-images.githubusercontent.com/22896307/151752096-06e81571-861c-4a8a-b374-08d623bc1336.png)
 
- Issues:
    - We might want to display more information about system output file formats (things we support for each task and description). This will require a change in the SDK.
    - Sample ID mismatch for QA tasks: https://github.com/ExpressAI/ExplainaBoard/issues/36
    - NER has a very different format. We briefly talked about some possible solutions for this but I don't recall we end up with a super concrete plan because we just started to implement system submission back then. I think it's finally time for us to actually address this issue 😎. Lets' talk about this when we meet this week!
---
Also, fixed a bug related to QA. closes https://github.com/neulab/ExplainaBoard/issues/73