### PR TITLE
feat: add py client release action

### DIFF
--- a/.github/workflows/py-client-release.yml
+++ b/.github/workflows/py-client-release.yml
@@ -1,0 +1,39 @@
+name: "Python API Client Release"
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build-and-release:
+    name: "Build and Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install -y default-jre
+          pip install wheel
+      - name: Generate Python Client
+        run: |
+          wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.29/swagger-codegen-cli-3.0.29.jar -O swagger-codegen-cli-3.0.29.jar
+          java -jar swagger-codegen-cli-3.0.29.jar generate -i openapi/openapi.yaml -l python -o python_client -DpackageName=explainaboard_api_client
+      - name: "build"
+        run: |
+          cd python_client
+          python setup.py bdist_wheel
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          title: "Python API Client"
+          prerelease: true
+          files: |
+            python_client/dist/*.whl


### PR DESCRIPTION
Implemented an action to release a python client for our web API on push to main. This should be useful for the CLI to interact with our web platform @pfliu-nlp . 

How to use it?
- Copy the released whl file URL and run `pip install https://github.com/neulab/explainaboard_web/releases/download/latest/explainaboard_api_client-1.0.0-py3-none-any.whl` to install the python client. (Please replace the URL with the latest URL.
- The generated package has a detailed README. I think it contains all the information.

This is just a quick implementation. Here are some things I think that may need more work on:
1. This repo doesn't have a version number so all the python clients released are tagged with "latest". I think pip will reinstall if the whl URL is different but it's not ideal because there's no obvious way of distinguishing versions. Also, I don't think GitHub will keep a roster of all the historical versions.
2. The generated client may be bad. I haven't really tested it.