### PR TITLE
Update wording of spinner

### DIFF
--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -188,7 +188,7 @@ export function SystemSubmitDrawer(props: Props) {
       destroyOnClose
       {...props}
     >
-      <Spin spinning={state === State.loading} tip="loading...">
+      <Spin spinning={state === State.loading} tip="processing...">
         <Form
           labelCol={{ span: 7 }}
           onFinish={submit}


### PR DESCRIPTION
Currently the spinner on system upload says "loading", but maybe "processing" is more accurate, so that the users know that there's a reasonable reason why it's taking time.