### PR TITLE
feat: refactor system.dataset

### DIFF
--- a/backend/src/impl/db_models/dataset_metadata_model.py
+++ b/backend/src/impl/db_models/dataset_metadata_model.py
@@ -26,13 +26,13 @@ class DatasetMetaDataModel(MetadataDBModel, DatasetMetadata):
         return cls.from_dict(document)
 
     @classmethod
-    def find(cls, page: int, page_size: int, dataset_ids: Optional[str] = None, dataset_name: Optional[str] = None, task: Optional[str] = None) -> DatasetsReturn:
+    def find(cls, page: int, page_size: int, dataset_ids: Optional[List[str]] = None, dataset_name: Optional[str] = None, task: Optional[str] = None) -> DatasetsReturn:
         """fuzzy match works like a `LIKE {name_prefix}%` operation now. can extend this and allow for 
         full text search in the future. TODO: add index for name"""
         filter: Dict[str, Any] = {}
         if dataset_ids:
             filter["_id"] = {
-                "$in": [ObjectId(_id) for _id in dataset_ids.split(",")]
+                "$in": [ObjectId(_id) for _id in dataset_ids]
             }
         if dataset_name:
             filter["dataset_name"] = {"$regex": rf"^{dataset_name}.*"}

--- a/backend/src/impl/db_models/system_metadata_model.py
+++ b/backend/src/impl/db_models/system_metadata_model.py
@@ -159,7 +159,8 @@ class SystemModel(MetadataDBModel, System):
         for doc in documents:
             if doc.get("dataset_metadata_id"):
                 dataset_ids.append(doc["dataset_metadata_id"])
-        datasets = DatasetMetaDataModel.find(0, 1000, dataset_ids).datasets
+        datasets = DatasetMetaDataModel.find(
+            0, 0, dataset_ids, no_limit=True).datasets
         dataset_dict = {}
         for dataset in datasets:
             dataset_dict[dataset.dataset_id] = dataset
@@ -171,6 +172,7 @@ class SystemModel(MetadataDBModel, System):
                                       "dataset_name": dataset.dataset_name, "tasks": dataset.tasks}
                 else:
                     doc["dataset"] = None
+                doc.pop("dataset_metadata_id")
         return SystemsReturn([cls.from_dict(doc) for doc in documents], total)
 
 

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -43,7 +43,8 @@ def datasets_dataset_id_get(dataset_id: str) -> DatasetMetaDataModel:
 
 
 def datasets_get(dataset_ids: Optional[str], dataset_name: Optional[str], task: Optional[str], page: int, page_size: int) -> DatasetsReturn:
-    return DatasetMetaDataModel.find(page, page_size, dataset_ids, dataset_name, task)
+    parsed_dataset_ids = dataset_ids.split(",") if dataset_ids else None
+    return DatasetMetaDataModel.find(page, page_size, parsed_dataset_ids, dataset_name, task)
 
 
 """ /systems """

--- a/frontend/src/components/AnalysisTable/index.tsx
+++ b/frontend/src/components/AnalysisTable/index.tsx
@@ -110,6 +110,7 @@ export function AnalysisTable({
       columns={columns}
       dataSource={dataSource}
       loading={pageState === PageState.loading}
+      rowKey="id"
       pagination={{
         total,
         showTotal: (total, range) =>

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -17,8 +17,7 @@ import { AnalysisReport, PrivateIcon, ErrorBoundary } from "..";
 const { Text, Link } = Typography;
 
 interface Props {
-  systemIDs: string[];
-  normalizedSystems: { [key: string]: SystemModel };
+  systems: SystemModel[];
   total: number;
   pageSize: number;
   /** 0 indexed */
@@ -33,8 +32,7 @@ interface Props {
 }
 
 export function SystemTableContent({
-  systemIDs,
-  normalizedSystems,
+  systems,
   page,
   total,
   pageSize,
@@ -46,9 +44,8 @@ export function SystemTableContent({
   activeSystemIDs,
   setActiveSystemIDs,
 }: Props) {
-  const systems = systemIDs.map((sysID) => normalizedSystems[sysID]);
-  const activeSystems = activeSystemIDs.map(
-    (sysID) => normalizedSystems[sysID]
+  const activeSystems = systems.filter((sys) =>
+    activeSystemIDs.includes(sys.system_id)
   );
   const analyses = activeSystems.map((sys) => sys["analysis"]);
 
@@ -116,7 +113,7 @@ export function SystemTableContent({
       title: "Dataset",
       fixed: "left",
       align: "center",
-      render: (value) => value,
+      render: (_, record) => record.dataset?.dataset_name || "unspecified",
     },
     {
       dataIndex: "language",
@@ -233,9 +230,7 @@ export function SystemTableContent({
           >
             <AnalysisReport
               systemIDs={activeSystemIDs}
-              systemNames={activeSystemIDs.map(
-                (sysID) => normalizedSystems[sysID].model_name
-              )}
+              systemNames={activeSystems.map((sys) => sys.model_name)}
               task={activeSystems[0]?.task}
               analyses={analyses}
             />

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -17,7 +17,7 @@ export interface Filter {
 }
 
 interface Props {
-  normalizedSystems: { [key: string]: SystemModel };
+  systems: SystemModel[];
   /** show/hide submit drawer */
   toggleSubmitDrawer: () => void;
   taskCategories: TaskCategory[];
@@ -28,7 +28,7 @@ interface Props {
   setActiveSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
 }
 export function SystemTableTools({
-  normalizedSystems,
+  systems,
   toggleSubmitDrawer,
   taskCategories,
   value,
@@ -37,9 +37,16 @@ export function SystemTableTools({
   selectedSystemIDs,
   setActiveSystemIDs,
 }: Props) {
-  const selectedSystemDatasetNames = new Set<string>(
-    selectedSystemIDs.map((sysIDs) => normalizedSystems[sysIDs].dataset_name)
-  );
+  function findSelectedSystemDatasetNames() {
+    const selectedSystems = systems.filter((sys) =>
+      selectedSystemIDs.includes(sys.system_id)
+    );
+    return new Set<string>(
+      selectedSystems.map((sys) => sys.dataset?.dataset_name || "unspecified")
+    );
+  }
+  const selectedSystemDatasetNames = findSelectedSystemDatasetNames();
+
   let analysisButton = (
     <Tooltip
       title={

--- a/frontend/src/models/SystemModel.ts
+++ b/frontend/src/models/SystemModel.ts
@@ -6,7 +6,6 @@ import { Features, Results } from "../components/AnalysisReport/types";
 export interface SystemModel extends Omit<System, "created_at"> {
   analysis: SystemAnalysisModel;
   created_at: Moment;
-  dataset_name: string;
 }
 
 /** A model that implements SystemAnalysis to provide useful methods */
@@ -25,13 +24,9 @@ export class SystemAnalysisModel implements SystemAnalysis {
 }
 
 /** construct a `SystemModel` from `System` */
-export const newSystemModel = (
-  system: System,
-  datasetName: string
-): SystemModel => {
+export const newSystemModel = (system: System): SystemModel => {
   return {
     ...system,
-    dataset_name: datasetName,
     created_at: moment(system.created_at),
     analysis: new SystemAnalysisModel(
       system.analysis.features,

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -476,8 +476,19 @@ components:
               type: boolean
             task:
               type: string
-            dataset_metadata_id:
-              type: string
+            dataset:
+              description: if not specified, it is undefined
+              type: object
+              properties:
+                dataset_id:
+                  type: string
+                dataset_name:
+                  type: string
+                tasks:
+                  type: array
+                  items:
+                    type: string
+              required: [dataset_id, dataset_name, tasks]
             model_name:
               type: string
             metric_names:


### PR DESCRIPTION
1. pass `dataset_name` to SDK when calling `get_processor()`. This allows us to support dataset aware analysis.
2. move "select * from systems JOIN dataset" logic to the backend. 
    - This makes it more efficient. It's also easier to use as the system model will always contain dataset information. If we need to add more information, all we need to do is to add more fields in the backend. If we want to cache dataset information or save a copy of that info in the **systems** collection, we can do so without changing the frontend.
    - The database schema has not been changed. We still store dataset_metadata_id only.
3. refactor systems table to make it easier to use
    - I think, for most situations, react automatically merges consecutive state updates into a batch update so there is no need to put several states into one big interface and treat it as one state.