### PR TITLE
Support multiple metrics and categorize histograms by metric tabs

### DIFF
--- a/frontend/src/components/AnalysisReport/index.tsx
+++ b/frontend/src/components/AnalysisReport/index.tsx
@@ -3,18 +3,22 @@ import { ResultFineGrainedParsed } from "./types";
 import { parse, compareBucketOfSamples } from "./utils";
 import { BarChart, AnalysisTable } from "../../components";
 import { Row, Col, Typography, Space, Tabs } from "antd";
-import { SystemAnalysisModel } from "../../models";
+import { SystemAnalysisModel, SystemModel } from "../../models";
 
 const { Title, Text } = Typography;
 const { TabPane } = Tabs;
 
 interface SystemAnalysisParsed {
-  resultsFineGrainedParsed: Array<ResultFineGrainedParsed[]>;
+  resultsFineGrainedParsed: Array<ResultFineGrainedParsed>[];
   // an element is a object key of a feature
   // used for retrieving the value from resultsFineGrainedParsed
   featureKeys: string[];
   // an element is a description/name of a feature to be displayed in the UI
   descriptions: string[];
+}
+
+interface MetricToSystemAnalysesParsed {
+  [key: string]: SystemAnalysisParsed[];
 }
 
 // Examples to be shown in the analysis table when a bar is clicked
@@ -37,7 +41,10 @@ interface ActiveSystemExamples {
 
 interface Props {
   systemIDs: string[];
-  systemNames: string[];
+  systemInfos: {
+    modelName: SystemModel["model_name"];
+    metricNames: SystemModel["metric_names"];
+  }[];
   task: string;
   analyses: SystemAnalysisModel[];
 }
@@ -48,19 +55,30 @@ export function AnalysisReport(props: Props) {
   // page number of the analysis table
   const [page, setPage] = useState(0);
 
-  const { task, systemIDs, systemNames, analyses } = props;
+  const { task, systemIDs, systemInfos, analyses } = props;
 
-  // The visualization chart of a fine-grained result is displayed using the "Grid" layout by Ant Design.
-  // Specifically, every chart is enclosed by <Col></Col>, and `chartNumPerRow` sets the number of charts
-  // to be enclosed by <Row></Row>.
-  let chartNumPerRow = 3; // Must be a factor of 24 since Ant divides a row into 24 sections!
+  /* The visualization chart of a fine-grained result is displayed using the "Grid" layout by Ant Design.
+  Specifically, every chart is enclosed by <Col></Col>, and `chartNumPerRow` sets the number of charts
+  to be enclosed by <Row></Row>. 
+  */
+  // Must be a factor of 24 since Ant divides a row into 24 sections!
+  let chartNumPerRow = 3;
   // pairwise analysis
   if (systemIDs.length > 1) {
     chartNumPerRow = 2;
   }
 
-  // Array to store every parsed system analysis
-  const systemAnalysesParsed: SystemAnalysisParsed[] = [];
+  /*
+  Take from the first element as the type and number of metrics should be 
+  invariant across sytems in pairwise analysis
+  */
+  const metricNames = systemInfos[0].metricNames;
+  const systemNames = systemInfos.map((sysInfo) => sysInfo.modelName);
+  const metricToSystemAnalysesParsed: MetricToSystemAnalysesParsed = {};
+  for (const metricName of metricNames) {
+    // Array to store every parsed system analysis
+    metricToSystemAnalysesParsed[metricName] = [];
+  }
 
   // Loop through each system analysis and parse
   for (let i = 0; i < systemIDs.length; i++) {
@@ -68,44 +86,75 @@ export function AnalysisReport(props: Props) {
     const analysis = analyses[i];
     const resultsFineGrained = analysis["results"]["fine_grained"];
 
-    // the parsed fine-grained results, used for visualization
-    const resultsFineGrainedParsed: Array<ResultFineGrainedParsed[]> = [
-      new Array<ResultFineGrainedParsed>(chartNumPerRow),
-    ];
+    const metricToParsedInfo: {
+      [key: string]: {
+        resultsFineGrainedParsed: Array<ResultFineGrainedParsed>[];
+        rowIdx: number;
+        chartNum: number;
+      };
+    } = {};
+    for (const metric of metricNames) {
+      // the parsed fine-grained results, used for visualization
+      metricToParsedInfo[metric].resultsFineGrainedParsed = [
+        new Array<ResultFineGrainedParsed>(chartNumPerRow),
+      ];
+      metricToParsedInfo[metric].rowIdx = 0;
+      metricToParsedInfo[metric].chartNum = 0;
+    }
     const featureKeys: string[] = [];
     const descriptions: string[] = [];
 
-    let rowIdx = 0;
-    let chartNum = 0;
-    for (const [key, featureVal] of Object.entries(analysis["features"])) {
-      const description = featureVal["description"] || key;
+    for (const [key, resultFineGrained] of Object.entries(resultsFineGrained)) {
+      // Attempt to get the description of feature from analysis.features.[key]
+      const featureVal = analysis["features"][key];
+      let description = key;
+      if (
+        featureVal !== undefined &&
+        typeof featureVal["description"] === "string"
+      ) {
+        description = featureVal["description"];
+      }
       featureKeys.push(key);
       descriptions.push(description);
 
-      // If a feature is bucket, it can be plotted in the bar chart.
-      if (featureVal.is_bucket) {
-        if (chartNum === chartNumPerRow) {
-          chartNum = 0;
-          resultsFineGrainedParsed.push(
+      // Add a row if the current row is full
+      for (const parsedInfo of Object.values(metricToParsedInfo)) {
+        if (parsedInfo.chartNum === chartNumPerRow) {
+          parsedInfo.chartNum = 0;
+          parsedInfo.resultsFineGrainedParsed.push(
             new Array<ResultFineGrainedParsed>(chartNumPerRow)
           );
-          rowIdx += 1;
+          parsedInfo.rowIdx += 1;
         }
-        resultsFineGrainedParsed[rowIdx][chartNum] = {
-          systemID,
-          description,
-          ...parse(task, resultsFineGrained[key]),
-        };
-        chartNum += 1;
+      }
+      const metricToResultFineGrainedParsed = parse(
+        systemID,
+        task,
+        description,
+        resultFineGrained
+      );
+      for (const [metric, resultFineGrainedParsed] of Object.entries(
+        metricToResultFineGrainedParsed
+      )) {
+        const rowIdx = metricToParsedInfo[metric].rowIdx;
+        const chartNum = metricToParsedInfo[metric].chartNum;
+        metricToParsedInfo[metric].resultsFineGrainedParsed[rowIdx][chartNum] =
+          resultFineGrainedParsed;
+        metricToParsedInfo[metric].chartNum += 1;
       }
     }
 
-    systemAnalysesParsed.push({
-      featureKeys,
-      descriptions,
-      resultsFineGrainedParsed,
-    });
+    for (const [metric, parsedInfo] of Object.entries(metricToParsedInfo)) {
+      const { resultsFineGrainedParsed } = parsedInfo;
+      metricToSystemAnalysesParsed[metric].push({
+        featureKeys,
+        descriptions,
+        resultsFineGrainedParsed,
+      });
+    }
   }
+
+  console.log(metricToSystemAnalysesParsed);
 
   // No bar selected
   let analysisTable = (
@@ -196,9 +245,9 @@ export function AnalysisReport(props: Props) {
     );
   }
 
-  // Get the parsed result from the first system for mapping
-  // featureKeys and descriptions are invariant information
-  // used in
+  /*Get the parsed result from the first system for mapping.
+  FeatureKeys and descriptions are invariant information
+  */
   const { resultsFineGrainedParsed, featureKeys, descriptions } =
     systemAnalysesParsed[0];
 

--- a/frontend/src/components/AnalysisReport/types.tsx
+++ b/frontend/src/components/AnalysisReport/types.tsx
@@ -59,3 +59,33 @@ export interface ResultFineGrainedParsed {
   numbersOfSamples: number[];
   confidenceScores: Array<[number, number]>;
 }
+
+export interface SystemAnalysisParsed {
+  resultsFineGrainedParsed: Array<ResultFineGrainedParsed>[];
+  /* key: feature key a object key of a feature
+  for retrieving the value from resultsFineGrainedParsed
+  value: description is a description/name of a feature to be displayed in the UI
+  */
+  featureKeyToDescription: { [key: string]: string };
+}
+
+export interface MetricToSystemAnalysesParsed {
+  [key: string]: SystemAnalysisParsed[];
+}
+
+// Examples to be shown in the analysis table when a bar is clicked
+export interface ActiveSystemExamples {
+  // invariant information across systems
+  // but depends on which bar or graph is clicked.
+  title: string;
+  barIndex: number;
+
+  // These are technically not invariant across sytems,
+  // but they may be in the future, and it's easier to keep them here for now.
+  featureKeyToDescription: SystemAnalysisParsed["featureKeyToDescription"];
+
+  // system-dependent information across systems
+  systemIndex: number;
+  // TODO the latter type is for NER | {[key: string]: string}[]
+  bucketOfSamplesList: string[][];
+}

--- a/frontend/src/components/AnalysisReport/types.tsx
+++ b/frontend/src/components/AnalysisReport/types.tsx
@@ -49,8 +49,8 @@ export interface FineGrainedElement {
 
 export interface ResultFineGrainedParsed {
   systemID: string;
-  description: string;
   task: string;
+  description: string;
   metricName: string;
   bucketNames: string[];
   // TODO the latter type is for NER

--- a/frontend/src/components/AnalysisReport/utils.tsx
+++ b/frontend/src/components/AnalysisReport/utils.tsx
@@ -1,4 +1,4 @@
-import { FineGrainedElement } from "./types";
+import { FineGrainedElement, ResultFineGrainedParsed } from "./types";
 
 function formatName(name: string) {
   if (Number.isNaN(Number(name))) {
@@ -12,7 +12,9 @@ function formatName(name: string) {
 
 // Parses a fineGrainedElements according to its task type.
 export function parse(
+  systemID: string,
   task: string,
+  description: string,
   fineGrainedElements: Array<FineGrainedElement[]>
 ) {
   const bucketNames: string[] = [];
@@ -20,66 +22,66 @@ export function parse(
   const numbersOfSamples: number[] = [];
   const confidenceScores: Array<[number, number]> = [];
   const bucketsOfSamples = [];
-
-  let metricName = "";
+  const parsedResult: { [key: string]: ResultFineGrainedParsed } = {};
 
   for (let i = 0; i < fineGrainedElements.length; i++) {
-    // For text classification, fineGrainedElements[i] always has length 1
-    // TODO: handle cases where length > 1
-    const fineGrainedElement = fineGrainedElements[i][0];
+    // fineGrainedElements[i] will have length > 1 when there exist multiple metrics.
+    for (const fineGrainedElement of fineGrainedElements[i]) {
+      bucketsOfSamples.push(fineGrainedElement.bucket_samples);
 
-    bucketsOfSamples.push(fineGrainedElement.bucket_samples);
+      const bucketNameArray = fineGrainedElement.bucket_name;
+      let bucketName = "";
+      switch (bucketNameArray.length) {
+        case 1: {
+          // Add two new lines so its text height is consistent with case 2.
+          // This allows the charts to have equal heights
+          const name = bucketNameArray[0] as string;
+          bucketName = `${formatName(name).toString()}\n\n`;
+          break;
+        }
+        case 2: {
+          const name1 = bucketNameArray[0] as string;
+          const name2 = bucketNameArray[1] as string;
+          bucketName = `${formatName(name1).toString()}\n|\n${formatName(
+            name2
+          ).toString()}`;
+          break;
+        }
+        default: {
+          // TODO: handle cases hwere length > 2
+          break;
+        }
+      }
 
-    const bucketNameArray = fineGrainedElement.bucket_name;
-    let bucketName = "";
-    switch (bucketNameArray.length) {
-      case 1: {
-        // Add two new lines so its text height is consistent with case 2.
-        // This allows the charts to have equal heights
-        const name = bucketNameArray[0] as string;
-        bucketName = `${formatName(name).toString()}\n\n`;
-        break;
+      const value = parseFloat(fineGrainedElement.value);
+      const nSamples = fineGrainedElement.n_samples;
+      const confidenceScoreLow = parseFloat(
+        fineGrainedElement.confidence_score_low
+      );
+      const confidenceScoreHigh = parseFloat(
+        fineGrainedElement.confidence_score_up
+      );
+      const metricName = fineGrainedElement.metric_name;
+      bucketNames.push(bucketName);
+      values.push(value);
+      numbersOfSamples.push(nSamples);
+      if (confidenceScoreLow !== 0 && confidenceScoreHigh !== 0) {
+        confidenceScores.push([confidenceScoreLow, confidenceScoreHigh]);
       }
-      case 2: {
-        const name1 = bucketNameArray[0] as string;
-        const name2 = bucketNameArray[1] as string;
-        bucketName = `${formatName(name1).toString()}\n|\n${formatName(
-          name2
-        ).toString()}`;
-        break;
-      }
-      default: {
-        // TODO: handle cases hwere length > 2
-        break;
-      }
-    }
-
-    const value = parseFloat(fineGrainedElement.value);
-    const nSamples = fineGrainedElement.n_samples;
-    const confidenceScoreLow = parseFloat(
-      fineGrainedElement.confidence_score_low
-    );
-    const confidenceScoreHigh = parseFloat(
-      fineGrainedElement.confidence_score_up
-    );
-    metricName = fineGrainedElement.metric_name;
-    bucketNames.push(bucketName);
-    values.push(value);
-    numbersOfSamples.push(nSamples);
-    if (confidenceScoreLow !== 0 && confidenceScoreHigh !== 0) {
-      confidenceScores.push([confidenceScoreLow, confidenceScoreHigh]);
+      parsedResult[metricName] = {
+        systemID,
+        task,
+        description,
+        metricName,
+        bucketNames,
+        bucketsOfSamples,
+        values,
+        numbersOfSamples,
+        confidenceScores,
+      };
     }
   }
-
-  return {
-    task,
-    metricName,
-    bucketNames,
-    bucketsOfSamples,
-    values,
-    numbersOfSamples,
-    confidenceScores,
-  };
+  return parsedResult;
 }
 
 export function compareBucketOfSamples(

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -228,9 +228,12 @@ export function SystemTableContent({
           >
             <AnalysisReport
               systemIDs={activeSystemIDs}
-              systemNames={activeSystemIDs.map(
-                (sysID) => normalizedSystems[sysID].model_name
-              )}
+              systemInfos={activeSystemIDs.map((sysID) => {
+                return {
+                  modelName: normalizedSystems[sysID].model_name,
+                  metricNames: normalizedSystems[sysID].metric_names,
+                };
+              })}
               task={activeSystems[0]?.task}
               analyses={analyses}
             />

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -53,6 +53,7 @@ export function SystemTableContent({
     dataIndex: metric,
     render: (_, record) => record.analysis.getMetirc(metric)?.value,
     title: metric,
+    width: 100,
     ellipsis: true,
     align: "center",
   }));


### PR DESCRIPTION
[UPDATE] #105 resolved. The PR is now mergeable.
⚠️ Perhaps wait until #105 is resolved.

This PR resolves #92 by supporting multiple metrics and categorizing histograms by metric tabs. It also adds a (temporary) fixed-width property to columns in the Systems table.

The fix for the problem in #105:
The `true_answers` field in QA is an object. Currently, I displaying its serialized form. So
```
{ 
answer_start: 284  // start position
text: two. // the text
}
```
becomes "answer_start: 284\ntext: two. ". We can beautify it in the future.

