### PR TITLE
Remove wrong folder

### DIFF
--- a/frotend/package-lock.json
+++ b/frotend/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "frotend",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
I accidentally committed a `frotend` folder. This PR removes it.