### PR TITLE
WIP: feat: support private datasets (metaphor qa)

### DIFF
--- a/backend/src/impl/db_models/system_metadata_model.py
+++ b/backend/src/impl/db_models/system_metadata_model.py
@@ -170,7 +170,7 @@ class SystemModel(MetadataDBModel, System):
                 document["dataset"] = {
                     "dataset_id": dataset.dataset_id,
                     "dataset_name": dataset.dataset_name,
-                    "sub_dataset": dataset.sub_dataset or "default",
+                    "sub_dataset": dataset.sub_dataset,
                     "tasks": dataset.tasks,
                 }
             else:

--- a/backend/src/impl/db_models/system_metadata_model.py
+++ b/backend/src/impl/db_models/system_metadata_model.py
@@ -13,6 +13,7 @@ from explainaboard import (
     get_datalab_loader,
     get_processor,
 )
+from explainaboard.processors.processor_registry import get_metric_list_for_processor
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.db_models.dataset_metadata_model import DatasetMetaDataModel
 from explainaboard_web.impl.db_models.db_model import DBModel, MetadataDBModel
@@ -93,9 +94,19 @@ class SystemModel(MetadataDBModel, System):
                     output_source=Source.in_memory,
                 ).load()
 
-        try:
-            system_output_data = load_sys_output()
+        def process():
             processor = get_processor(metadata.task)
+            metrics_lookup = {
+                metric.name: metric
+                for metric in get_metric_list_for_processor(metadata.task)
+            }
+            metric_configs = []
+            for metric_name in metadata.metric_names:
+                if metric_name not in metrics_lookup:
+                    abort_with_error_message(
+                        400, f"{metric_name} is not a supported metric"
+                    )
+                metric_configs.append(metrics_lookup[metric_name])
             processor_metadata = {
                 **metadata.to_dict(),
                 "task_name": metadata.task,
@@ -104,11 +115,16 @@ class SystemModel(MetadataDBModel, System):
                 if system.dataset
                 else None,
                 "dataset_split": metadata.dataset_split,
+                "metric_configs": metric_configs,
             }
 
-            overall_statistics = processor.get_overall_statistics(
+            return processor.get_overall_statistics(
                 metadata=processor_metadata, sys_output=system_output_data
             )
+
+        try:
+            system_output_data = load_sys_output()
+            overall_statistics = process()
             metric_stats = [
                 binarize_bson(metric_stat.get_data())
                 for metric_stat in overall_statistics.metric_stats

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -11,6 +11,7 @@ from explainaboard import (
     get_processor,
     get_task_categories,
 )
+from explainaboard import metric as exb_metric
 from explainaboard.feature import (
     BucketInfo,
     ClassLabel,
@@ -20,7 +21,7 @@ from explainaboard.feature import (
     Span,
     Value,
 )
-from explainaboard.info import Result, SysOutputInfo
+from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.loader_registry import get_supported_file_types_for_loader
 from explainaboard.metric import MetricStats
 from explainaboard.processors.processor_registry import get_metric_list_for_processor
@@ -288,7 +289,14 @@ def systems_analyses_post(body: SystemsAnalysesBody):
                 setting = [tuple(interval) for interval in custom_bucket_info.setting]
                 feature.bucket_info.setting = setting
             system_output_info.features[feature_name] = feature
-        system_output_info.results = Result(**system_output_info.results)
+
+        metric_configs = [
+            getattr(exb_metric, metric_config_dict["cls"])(**metric_config_dict)
+            for metric_config_dict in system_output_info.metric_configs
+        ]
+
+        system_output_info.metric_configs = metric_configs
+
         # The order of getting the processor first then setting
         # the tokenizer is unnatural, but in the SDK get_default_tokenizer
         # relies on the processor's TaskType inforamtion

--- a/backend/src/impl/private_dataset.py
+++ b/backend/src/impl/private_dataset.py
@@ -1,0 +1,11 @@
+from dataclasses import astuple
+
+from explainaboard import DatalabLoaderOption
+
+PRIVATE_DATASETS = [DatalabLoaderOption("metaphor_qa", None, "test")]
+
+_private_dataset_lookup = set(astuple(dataset) for dataset in PRIVATE_DATASETS)
+
+
+def is_private_dataset(dataset: DatalabLoaderOption):
+    return astuple(dataset) in _private_dataset_lookup

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -7,6 +7,6 @@ Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
 pyjwt[crypto] == 2.3.0
-explainaboard == 0.8.11
+explainaboard == 0.8.12
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pre-commit

--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -84,7 +84,7 @@ export function AnalysisDrawer({
       const task = firstSystemInfo.task_name;
       const metricToSystemAnalysesParsed = getMetricToSystemAnalysesParsed(
         task,
-        firstSystemInfo.metric_names,
+        [], // FIX
         activeSystems,
         singleAnalyses
       );

--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -82,9 +82,13 @@ export function AnalysisDrawer({
       */
       const firstSystemInfo = activeSystems[0].system_info;
       const task = firstSystemInfo.task_name;
+
+      const metricNames = firstSystemInfo.metric_configs.map(
+        (config) => config.name
+      );
       const metricToSystemAnalysesParsed = getMetricToSystemAnalysesParsed(
         task,
-        [], // FIX
+        metricNames,
         activeSystems,
         singleAnalyses
       );

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -32,6 +32,8 @@ export function parse(
   featureKey: string,
   bucketInfo: SystemInfoFeature["bucket_info"]
 ) {
+  console.log(metricNames);
+
   const decimalPlaces = 3;
   const parsedResult: { [metricName: string]: ResultFineGrainedParsed } = {};
   for (const metricName of metricNames) {

--- a/frontend/src/components/TaskSelect.tsx
+++ b/frontend/src/components/TaskSelect.tsx
@@ -11,8 +11,8 @@ export function TaskSelect({ taskCategories, ...props }: Props) {
     <Select showSearch {...props}>
       {taskCategories.map(({ name, tasks }, i) => (
         <Select.OptGroup label={name} key={i}>
-          {tasks.map(({ name, supported }) => (
-            <Select.Option value={name} key={name} disabled={!supported}>
+          {tasks.map(({ name }) => (
+            <Select.Option value={name} key={name}>
               {name}
             </Select.Option>
           ))}

--- a/frontend/src/pages/LeaderboardHome/index.tsx
+++ b/frontend/src/pages/LeaderboardHome/index.tsx
@@ -32,7 +32,7 @@ export function LeaderboardHome() {
             }
           >
             <Row gutter={[16, 16]} className="tasks-grid">
-              {tasks.map(({ name, supported }) => (
+              {tasks.map(({ name }) => (
                 <Col key={name} span={6}>
                   <Card
                     className="task-card"
@@ -42,7 +42,6 @@ export function LeaderboardHome() {
                     }
                   >
                     {name}
-                    {!supported && " (not available at this moment)"}
                   </Card>
                 </Col>
               ))}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -681,12 +681,12 @@ components:
                   type: string
                 sub_dataset:
                   type: string
-                  default: default
+                  nullable: true
                 tasks:
                   type: array
                   items:
                     type: string
-              required: [dataset_id, dataset_name, sub_dataset, tasks]
+              required: [dataset_id, dataset_name, tasks]
             paper_info:
               $ref: "#/components/schemas/PaperInfo"
             code:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -508,6 +508,7 @@ components:
           tokenizer,
           features,
           results,
+          metric_configs,
         ]
 
     APIError:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -446,11 +446,6 @@ components:
         dataset_split:
           type: string
           nullable: true
-        metric_names:
-          type: array
-          items:
-            type: string
-            example: "F1Score"
         language:
           type: string
           example: en
@@ -464,8 +459,19 @@ components:
           type: object
           nullable: True
         metric_configs:
-          type: object
-          nullable: True
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              language:
+                type: string
+                nullable: True
+              cls:
+                type: string
+            additionalProperties: true
+            required: [name, cls]
         tokenizer:
           type: object
           properties:
@@ -495,7 +501,6 @@ components:
         [
           task_name,
           model_name,
-          metric_names,
           language,
           reload_stat,
           is_print_case,
@@ -546,8 +551,6 @@ components:
       properties:
         name:
           type: string
-        supported:
-          type: boolean
         description:
           type: string
         supported_metrics:
@@ -566,8 +569,7 @@ components:
               items:
                 type: string
           required: [custom_dataset, system_output]
-      required:
-        [name, supported, description, supported_metrics, supported_formats]
+      required: [name, description, supported_metrics, supported_formats]
 
     PaperInfo:
       type: object


### PR DESCRIPTION
This PR cannot be tested until the bug for multiple-choice QA is fixed. #85 @OscarWang114 is working on fixing this bug.
- returns 403 for GET /systems/{system_id}/outputs if the associated dataset is private
- currently, metaphor QA test split is the only private dataset
- previously, "default" is passed as the sub dataset name to the SDK if the user doesn't specify one (or if the dataset entry in the database doesn't have this field). I read through the code in explainaboard SDK. It seems that I should actually pass in `None` if subdataset is not specified.
    - For example, if I pass in (metaphor_qa, default, test) to `get_datalab_loader`, the following error is raised:
    ```BuilderConfig default not found. Available: ['small', 'medium', 'large']```
     I think what this means is that the default subdataset is not called "default". @pfliu-nlp Could you please check if this is the correct way of specifying sub dataset names?