### PR TITLE
3 types of leaderboards: task-based, dataset-based, subdataset-based 

### DIFF
--- a/backend/src/impl/db_models/system_metadata_model.py
+++ b/backend/src/impl/db_models/system_metadata_model.py
@@ -272,6 +272,8 @@ class SystemModel(MetadataDBModel, System):
         page_size: int,
         system_name: Optional[str],
         task: Optional[str],
+        dataset_name: Optional[str],
+        subdataset_name: Optional[str],
         sort: Optional[list],
         creator: Optional[str],
         include_datasets: bool = False,
@@ -285,10 +287,15 @@ class SystemModel(MetadataDBModel, System):
         if system_name:
             filter["model_name"] = {"$regex": rf"^{system_name}.*"}
         if task:
-            filter["task"] = task
+            filter["system_info.task_name"] = task
+        if dataset_name:
+            filter["system_info.dataset_name"] = dataset_name
+        if subdataset_name:
+            filter["system_info.sub_dataset_name"] = subdataset_name
         if creator:
             filter["creator"] = creator
         filter["$or"] = [{"is_private": False}, {"creator": get_user().email}]
+
         cursor, total = super().find(filter, sort, page * page_size, page_size)
         documents = list(cursor)
 

--- a/backend/src/impl/db_models/system_metadata_model.py
+++ b/backend/src/impl/db_models/system_metadata_model.py
@@ -274,6 +274,7 @@ class SystemModel(MetadataDBModel, System):
         task: Optional[str],
         dataset_name: Optional[str],
         subdataset_name: Optional[str],
+        split: Optional[str],
         sort: Optional[list],
         creator: Optional[str],
         include_datasets: bool = False,
@@ -292,6 +293,8 @@ class SystemModel(MetadataDBModel, System):
             filter["system_info.dataset_name"] = dataset_name
         if subdataset_name:
             filter["system_info.sub_dataset_name"] = subdataset_name
+        if split:
+            filter["system_info.dataset_split"] = split
         if creator:
             filter["creator"] = creator
         filter["$or"] = [{"is_private": False}, {"creator": get_user().email}]

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -229,6 +229,9 @@ def systems_analyses_post(body: SystemsAnalysesBody):
     system_ids: list = system_ids_str.split(",")
     system_name = None
     task = None
+    dataset_name = None
+    subdataset_name = None
+    split = None
     creator = None
     page = 0
     page_size = len(system_ids)
@@ -237,8 +240,11 @@ def systems_analyses_post(body: SystemsAnalysesBody):
         system_ids,
         page,
         page_size,
-        system_name,
         task,
+        system_name,
+        dataset_name,
+        subdataset_name,
+        split,
         sort,
         creator,
         include_metric_stats=True,

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -125,6 +125,8 @@ def systems_system_id_get(system_id: str) -> SystemModel:
 def systems_get(
     system_name: Optional[str],
     task: Optional[str],
+    dataset: Optional[str],
+    subdataset: Optional[str],
     page: int,
     page_size: int,
     sort_field: str,
@@ -144,7 +146,15 @@ def systems_get(
     dir = ASCENDING if sort_direction == "asc" else DESCENDING
 
     return SystemModel.find(
-        ids, page, page_size, system_name, task, [(sort_field, dir)], creator
+        ids,
+        page,
+        page_size,
+        system_name,
+        task,
+        dataset,
+        subdataset,
+        [(sort_field, dir)],
+        creator,
     )
 
 

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -142,7 +142,7 @@ def systems_get(
     if sort_direction not in ["asc", "desc"]:
         abort_with_error_message(400, "sort_direction needs to be one of asc or desc")
     if sort_field != "created_at":
-        sort_field = f"analysis.results.overall.{sort_field}.value"
+        sort_field = f"system_info.results.overall.{sort_field}.value"
 
     dir = ASCENDING if sort_direction == "asc" else DESCENDING
 

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -127,6 +127,7 @@ def systems_get(
     task: Optional[str],
     dataset: Optional[str],
     subdataset: Optional[str],
+    split: Optional[str],
     page: int,
     page_size: int,
     sort_field: str,
@@ -153,6 +154,7 @@ def systems_get(
         task,
         dataset,
         subdataset,
+        split,
         [(sort_field, dir)],
         creator,
     )

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -32,8 +32,6 @@ export function parse(
   featureKey: string,
   bucketInfo: SystemInfoFeature["bucket_info"]
 ) {
-  console.log(metricNames);
-
   const decimalPlaces = 3;
   const parsedResult: { [metricName: string]: ResultFineGrainedParsed } = {};
   for (const metricName of metricNames) {

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -122,6 +122,14 @@ export function SystemTableContent({
     },
     {
       dataIndex: ["system_info", "language"],
+      width: 110,
+      title: "Dataset split",
+      fixed: "left",
+      align: "center",
+      render: (_, record) => record.system_info.dataset_split || "unspecified",
+    },
+    {
+      dataIndex: ["system_info", "language"],
       width: 100,
       title: "Language",
       align: "center",

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -14,6 +14,7 @@ export interface Filter {
   task?: string;
   sortField: string;
   sortDir: "asc" | "desc";
+  split: string;
 }
 
 interface Props {
@@ -112,6 +113,16 @@ export function SystemTableTools({
         {analysisButton}
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
+        <Select
+          options={["test", "validation", "train", "all"].map((opt) => ({
+            value: opt,
+            label: opt,
+          }))}
+          value={value.split}
+          onChange={(value) => onChange({ split: value })}
+          placeholder="Dataset split"
+          style={{ minWidth: "120px" }}
+        />
         <TaskSelect
           taskCategories={taskCategories}
           allowClear

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -12,10 +12,16 @@ import { TaskCategory } from "../../clients/openapi";
 interface Props {
   /**initial value for task filter */
   initialTaskFilter?: string;
+  dataset?: string;
+  subdataset?: string;
 }
 
 /** A table that lists all systems */
-export function SystemsTable({ initialTaskFilter }: Props) {
+export function SystemsTable({
+  initialTaskFilter,
+  dataset,
+  subdataset,
+}: Props) {
   const [pageState, setPageState] = useState(PageState.loading);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
@@ -84,6 +90,8 @@ export function SystemsTable({ initialTaskFilter }: Props) {
         await backendClient.systemsGet(
           nameFilter || undefined,
           taskFilter,
+          dataset || undefined,
+          subdataset || undefined,
           page,
           pageSize,
           sortField,
@@ -97,6 +105,8 @@ export function SystemsTable({ initialTaskFilter }: Props) {
   }, [
     nameFilter,
     taskFilter,
+    dataset,
+    subdataset,
     page,
     pageSize,
     sortField,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -34,6 +34,7 @@ export function SystemsTable({
   const [taskFilter, setTaskFilter] = useState(initialTaskFilter);
   const [sortField, setSortField] = useState("created_at");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [split, setSplit] = useState<string>("all");
 
   // submit
   const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);
@@ -86,12 +87,14 @@ export function SystemsTable({
   useEffect(() => {
     async function refreshSystems() {
       setPageState(PageState.loading);
+      const datasetSplit = split === "all" ? undefined : split;
       const { systems: newSystems, total: newTotal } =
         await backendClient.systemsGet(
           nameFilter || undefined,
           taskFilter,
           dataset || undefined,
           subdataset || undefined,
+          datasetSplit || undefined,
           page,
           pageSize,
           sortField,
@@ -107,6 +110,7 @@ export function SystemsTable({
     taskFilter,
     dataset,
     subdataset,
+    split,
     page,
     pageSize,
     sortField,
@@ -120,11 +124,13 @@ export function SystemsTable({
     task,
     sortField: newSortField,
     sortDir: newSortDir,
+    split: newSplit,
   }: Partial<Filter>) {
     if (name != null) setNameFilter(name);
     if (task != null) setTaskFilter(task || undefined);
     if (newSortField != null) setSortField(newSortField);
     if (newSortDir != null) setSortDir(newSortDir);
+    if (newSplit != null) setSplit(newSplit);
     setPage(0);
     setSelectedSystemIDs([]);
   }
@@ -135,7 +141,13 @@ export function SystemsTable({
         systems={systems}
         toggleSubmitDrawer={() => setSubmitDrawerVisible((visible) => !visible)}
         taskCategories={taskCategories}
-        value={{ task: taskFilter, name: nameFilter, sortField, sortDir }}
+        value={{
+          task: taskFilter,
+          name: nameFilter,
+          sortField,
+          sortDir,
+          split,
+        }}
         onChange={onFilterChange}
         metricOptions={metricNames}
         selectedSystemIDs={selectedSystemIDs}

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -12,8 +12,13 @@ import "./index.css";
 import { ColumnsType } from "antd/lib/table";
 import { DatasetMetadata } from "../../clients/openapi";
 import { backendClient } from "../../clients";
-import { generateDataLabURL, PageState } from "../../utils";
+import {
+  generateDataLabURL,
+  generateLeaderboardURL,
+  PageState,
+} from "../../utils";
 import { useHistory } from "react-router";
+import { Link } from "react-router-dom";
 
 /**
  * Dataset Page
@@ -136,6 +141,19 @@ const columns: ColumnsType<DatasetMetadata> = [
           <Tag key={i}>{task}</Tag>
         ))}
       </span>
+    ),
+  },
+  {
+    dataIndex: "",
+    title: "Leaderboard",
+    render: (_, record) => (
+      <Typography.Link href={""} target="_blank">
+        <Link
+          to={generateLeaderboardURL(record.dataset_name, record.sub_dataset)}
+        >
+          Leaderboard
+        </Link>
+      </Typography.Link>
     ),
   },
   {

--- a/frontend/src/pages/LeaderboardHome/index.tsx
+++ b/frontend/src/pages/LeaderboardHome/index.tsx
@@ -38,7 +38,7 @@ export function LeaderboardHome() {
                     className="task-card"
                     title={name}
                     onClick={() =>
-                      history.push(document.location.pathname + "/" + name)
+                      history.push(`${document.location.pathname}?task=${name}`)
                     }
                   >
                     {name}

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import "./index.css";
 import { PageHeader } from "antd";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { SystemsTable } from "../../components";
+import { LeaderboardHome } from "../LeaderboardHome";
+
+function useQuery() {
+  const { search } = useLocation();
+  return React.useMemo(() => new URLSearchParams(search), [search]);
+}
 
 /**
  * TODO:
@@ -10,18 +16,38 @@ import { SystemsTable } from "../../components";
  */
 export function LeaderboardPage() {
   const history = useHistory();
-  const { task } = useParams<{ task: string }>();
+  const query = useQuery();
+  const task = query.get("task") || undefined;
+  const dataset = query.get("dataset") || undefined;
+  const subdataset = query.get("subdataset") || undefined;
 
-  return (
-    <div>
-      <PageHeader
-        onBack={() => history.goBack()}
-        title={task + " Leaderboard"}
-        subTitle={`Leaderboard for ${task}`}
-      />
-      <div style={{ padding: "0 10px" }}>
-        <SystemsTable initialTaskFilter={task} />
+  if (task || dataset || subdataset) {
+    const title = subdataset || dataset || task;
+    let subTitle;
+    if (subdataset) {
+      subTitle = `subdataset: ${subdataset}`;
+    } else if (dataset) {
+      subTitle = `dataset: ${dataset}`;
+    } else {
+      subTitle = `task: ${task}`;
+    }
+    return (
+      <div>
+        <PageHeader
+          onBack={() => history.goBack()}
+          title={title + " Leaderboard"}
+          subTitle={`Leaderboard for ${subTitle}`}
+        />
+        <div style={{ padding: "0 10px" }}>
+          <SystemsTable
+            initialTaskFilter={task}
+            dataset={dataset}
+            subdataset={subdataset}
+          />
+        </div>
       </div>
-    </div>
-  );
+    );
+  } else {
+    return <LeaderboardHome />;
+  }
 }

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -10,7 +10,6 @@ import {
 import {
   DatasetsPage,
   Home,
-  LeaderboardHome,
   LeaderboardPage,
   LoginCallback,
   SystemsPage,
@@ -51,8 +50,8 @@ const routes: Route[] = [
     path: "/leaderboards",
     title: "Leaderboards",
     icon: <TableOutlined />,
-    children: <LeaderboardHome />,
-    exact: true,
+    children: <LeaderboardPage />,
+    requireLogin: true,
   },
   {
     path: "/terms",
@@ -60,13 +59,6 @@ const routes: Route[] = [
     exact: true,
     icon: <FileOutlined />,
     children: <TermsPage />,
-  },
-  {
-    path: "/leaderboards/:task",
-    exact: true,
-    children: <LeaderboardPage />,
-    hideFromMenu: true,
-    requireLogin: true,
   },
   {
     path: "/login-callback",

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -35,4 +35,15 @@ export function generateDataLabURL(datasetID: string): string {
   return `http://datalab.nlpedia.ai/normal_dataset/${datasetID}/dataset_metadata`;
 }
 
+export function generateLeaderboardURL(
+  dataset: string,
+  subdataset: string | undefined
+): string {
+  const url = `/leaderboards?dataset=${dataset}`;
+  if (subdataset === undefined) {
+    return url;
+  }
+  return `${url}&subdataset=${subdataset}`;
+}
+
 export * from "./typing_utils";

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -174,6 +174,11 @@ paths:
           schema:
             type: string
         - in: query
+          name: split
+          description: dataset split
+          schema:
+            type: string        
+        - in: query
           name: page
           description: page number (0 indexed)
           schema:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -164,6 +164,16 @@ paths:
           schema:
             type: string
         - in: query
+          name: dataset
+          description: dataset name
+          schema:
+            type: string
+        - in: query
+          name: subdataset
+          description: subdataset name
+          schema:
+            type: string
+        - in: query
           name: page
           description: page number (0 indexed)
           schema:


### PR DESCRIPTION
The leaderboard is more versatile and flexible now. It can be either task-based, dataset-based, or subdataset-based. 

The most direct way of accessing any type of leaderboard is via URL:
- task-based: `/leaderboards?task=text-classification`
- dataset-based: `/leaderboards?dataset=ethos`
- subdataset-based: `/leaderboards?dataset=ethos&subdataset=binary`

For accessing a subdataset-based leaderboard via navigation, I only implemented one entry for now: Click "Datasets" -> each dataset row contains a leaderboard link (image 1). If the row has a subdataset, the linked leaderboard is a subdataset-based leaderboard (image 2), If the row has no subdataset, the linked leaderboard is a dataset-based leaderboard (image 3).

Update:  Dataset split tab is added! 
<img width="1262" alt="Screen Shot 2022-04-25 at 9 46 24 PM" src="https://user-images.githubusercontent.com/30998659/165202950-bf202488-66dc-4853-a5c0-ed44f62898d2.png">

<img width="1255" alt="Screen Shot 2022-04-25 at 2 53 15 PM" src="https://user-images.githubusercontent.com/30998659/165154963-8bc0e887-1382-4743-8acf-a01367b9ad57.png">

<img width="1264" alt="Screen Shot 2022-04-25 at 2 58 55 PM" src="https://user-images.githubusercontent.com/30998659/165155949-629db393-4adc-4eff-9d1b-67b83ea08c02.png">

<img width="1259" alt="Screen Shot 2022-04-25 at 2 54 18 PM" src="https://user-images.githubusercontent.com/30998659/165155123-442d796c-b58e-445e-bdc0-fbaf2648aa02.png">


