### PR TITLE
Fix split tab placeholder & auto-resetting buckets in analysis

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -49,7 +49,7 @@ export function AnalysisDrawer({
 
   useEffect(() => {
     async function refreshAnalyses(
-      featureKeyToBucketInfo: SystemsAnalysesBody["feature_to_bucket_info"]
+      featureKeyToBucketInfoToPost: SystemsAnalysesBody["feature_to_bucket_info"]
     ) {
       setPageState(PageState.loading);
       const systemAnalysesReturn: SystemAnalysesReturn | null =
@@ -62,7 +62,7 @@ export function AnalysisDrawer({
               system_ids: activeSystemIDs.join(","),
               // Hardcoded to false. TODO(chihhao) wait for SDK's update
               pairwise_performance_gap: false,
-              feature_to_bucket_info: featureKeyToBucketInfo,
+              feature_to_bucket_info: featureKeyToBucketInfoToPost,
             })
             .then((systemAnalysesReturn) => {
               clearTimeout(timeoutID);
@@ -122,7 +122,10 @@ export function AnalysisDrawer({
               0,
               bucketRightBounds.length - 1
             ),
-            updated: false,
+            /* A bucket may remain updated (i.e. different from the init value of SDK) 
+            across multiple post calls, so we must reuse this information from the state
+            */
+            updated: featureKeyToBucketInfo[featureKey]?.updated || false,
           };
         }
       }

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -118,9 +118,8 @@ export function SystemTableTools({
             value: opt,
             label: opt,
           }))}
-          value={value.split}
-          onChange={(value) => onChange({ split: value })}
           placeholder="Dataset split"
+          onChange={(value) => onChange({ split: value })}
           style={{ minWidth: "120px" }}
         />
         <TaskSelect


### PR DESCRIPTION
1. The split tab placeholder's name is more descriptive now.
<img width="670" alt="Screen Shot 2022-04-26 at 11 53 19 AM" src="https://user-images.githubusercontent.com/30998659/165341646-def80624-7fb6-4e36-8c72-6ebef1d531e3.png">

2. Fixed a bug that causes buckets to get reset if a user updates analysis multiple times across different charts.