### PR TITLE
refine feature deserialization & remove `is_pre_computed`

### DIFF
--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -12,15 +12,7 @@ from explainaboard import (
     get_task_categories,
 )
 from explainaboard import metric as exb_metric
-from explainaboard.feature import (
-    BucketInfo,
-    ClassLabel,
-    Position,
-    Sequence,
-    Set,
-    Span,
-    Value,
-)
+from explainaboard.feature import FeatureType
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.loader_registry import get_supported_file_types_for_loader
 from explainaboard.metric import MetricStats
@@ -271,31 +263,9 @@ def systems_analyses_post(body: SystemsAnalysesBody):
         # add proper from_dict() methods in SDK
         for feature_name, feature in system_output_info.features.items():
             # TODO Feature is not getting from_dict()ed properly, hardcode for now:
-            _type = feature["_type"]
-            feature.pop("_type")
-            if _type == ClassLabel._type:
-                feature = ClassLabel(**feature)
-            elif _type == Sequence._type:
-                feature = Sequence(**feature)
-            elif _type == Set._type:
-                feature = Set(**feature)
-            elif _type == Position._type:
-                feature = Position(**feature)
-            elif _type == Span._type:
-                feature = Span(**feature)
-            elif _type == Value._type:
-                feature = Value(**feature)
 
-            bucket_info = (
-                None
-                if isinstance(feature, Sequence) or isinstance(feature, Set)
-                else feature.bucket_info
-            )
+            feature = FeatureType.from_dict(feature)  # dict -> Feature
 
-            if bucket_info is not None:
-                bucket_info = BucketInfo(**bucket_info)
-
-            feature.bucket_info = bucket_info
             # user-defined bucket info
             if feature_name in custom_feature_to_bucket_info:
                 custom_bucket_info = custom_feature_to_bucket_info[feature_name]

--- a/frontend/src/components/Analysis/types.tsx
+++ b/frontend/src/components/Analysis/types.tsx
@@ -12,7 +12,6 @@ export interface FeatureVal {
   description: string | null | undefined;
   id: null;
   is_bucket: boolean;
-  is_pre_computed: boolean;
   dtype?: string;
   names?: string[];
   names_file?: null;
@@ -108,7 +107,6 @@ export interface SystemInfoFeature {
   description: string | null;
   dtype?: string;
   is_bucket: boolean;
-  is_pre_computed: boolean;
   require_training_set: boolean;
   _type: string;
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -398,8 +398,6 @@ components:
           type: boolean
         require_training_set:
           type: boolean
-        is_pre_computed:
-          type: boolean
         bucket_info:
           # TODO(chihhao) define detailed fields
           type: object
@@ -431,8 +429,6 @@ components:
         is_bucket:
           type: boolean
         require_training_set:
-          type: boolean
-        is_pre_computed:
           type: boolean
         bucket_info:
           type: object


### PR DESCRIPTION
this PR is used to fix error `B3` in https://github.com/neulab/explainaboard_web/issues/127

The refactored feature class simplifies feature deserialization but also brings some other potentially painful things since the redundant  field `is_pre_computed` has been removed, which results in several downstream changes:

* `types.tsx`
* `openapi.yaml`
* DB should be modified a little bit otherwise old system output files probably cannot be analyzed