### PR TITLE
Modify dataset UI

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -79,7 +79,7 @@ class SystemDBUtils:
         split: Optional[str],
         sort: Optional[list],
         creator: Optional[str],
-        include_datasets: bool = False,
+        include_datasets: bool = True,
         include_metric_stats: bool = False,
     ) -> SystemsReturn:
         """find multiple systems that matches the filters"""

--- a/frontend/src/components/SystemSubmitDrawer/DatasetSelect.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/DatasetSelect.tsx
@@ -94,7 +94,7 @@ function DatasetSelectLabel({ dataset }: { dataset: DatasetMetadata }) {
       </span>
 
       <Typography.Link
-        href={generateDataLabURL(dataset_id)}
+        href={generateDataLabURL(dataset_name)}
         target="_blank"
         onClick={(e) => e.stopPropagation()}
       >

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -109,7 +109,7 @@ export function SystemTableContent({
         record.dataset?.dataset_name ? (
           <Tooltip title="view dataset in DataLab">
             <Typography.Link
-              href={generateDataLabURL(record.dataset.dataset_id)}
+              href={generateDataLabURL(record.dataset.dataset_name)}
               target="_blank"
             >
               {record.dataset.dataset_name}

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -107,16 +107,6 @@ const columns: ColumnsType<DatasetMetadata> = [
     align: "center",
   },
   {
-    dataIndex: "dataset_id",
-    title: "ID",
-    width: 230,
-    render: (value) => (
-      <Typography.Paragraph copyable style={{ marginBottom: 0 }}>
-        {value}
-      </Typography.Paragraph>
-    ),
-  },
-  {
     dataIndex: "dataset_name",
     title: "Name",
   },

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -1,13 +1,5 @@
 import React, { useEffect, useState } from "react";
-import {
-  Divider,
-  Input,
-  PageHeader,
-  Space,
-  Table,
-  Tag,
-  Typography,
-} from "antd";
+import { Input, PageHeader, Space, Table, Tag, Typography } from "antd";
 import "./index.css";
 import { ColumnsType } from "antd/lib/table";
 import { DatasetMetadata } from "../../clients/openapi";
@@ -162,18 +154,10 @@ const columns: ColumnsType<DatasetMetadata> = [
     render: (_, record) => (
       <>
         <Typography.Link
-          href={generateDataLabURL(record.dataset_id)}
+          href={generateDataLabURL(record.dataset_name)}
           target="_blank"
         >
           DataLab
-        </Typography.Link>
-        <Divider type="vertical" />
-        <Typography.Link
-          href={record.huggingface_link}
-          target="_blank"
-          disabled={!record.huggingface_link}
-        >
-          Hugging Face
         </Typography.Link>
       </>
     ),

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -31,8 +31,8 @@ export function findTask(taskCategories: TaskCategory[], taskName: string) {
 }
 
 /**generates datalab URL for a dataset. Simple concatenation (link may not be valid) */
-export function generateDataLabURL(datasetID: string): string {
-  return `http://datalab.nlpedia.ai/normal_dataset/${datasetID}/dataset_metadata`;
+export function generateDataLabURL(datasetName: string): string {
+  return `https://github.com/ExpressAI/DataLab/blob/main/datasets/${datasetName}/${datasetName}.py`;
 }
 
 export function generateLeaderboardURL(


### PR DESCRIPTION
Follow up commit to https://github.com/neulab/explainaboard_web/pull/153

Modifies the UI to make sure it works with the new datasets info, and removes the dataset UI from the browsing interface.

In combination with the previous commits, this fixes https://github.com/neulab/explainaboard_web/issues/137