### PR TITLE
use cls_name for metrics and tokenizer

### DIFF
--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -7,7 +7,7 @@ Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
 pyjwt[crypto] == 2.3.0
-explainaboard == 0.8.14
+explainaboard == 0.8.15
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pre-commit
 marisa_trie

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -486,14 +486,14 @@ components:
               language:
                 type: string
                 nullable: True
-              cls:
+              cls_name:
                 type: string
             additionalProperties: true
-            required: [name, cls]
+            required: [name, cls_name]
         tokenizer:
           type: object
           properties:
-            cls:
+            cls_name:
               type: string
               example: "SingleSpaceTokenizer"
         features:


### PR DESCRIPTION
Following https://github.com/neulab/ExplainaBoard/pull/298, this PR updates explainaboard_web to use `cls_name` instead of `cls`. I have migrated the DB to the new schema (added "cls_name" but I think some of the old records still don't work because of the changes to `FeatureType` https://github.com/neulab/ExplainaBoard/issues/292)