### PR TITLE
feat(fe): refresh systems list when login state changes

### DIFF
--- a/frontend/src/components/SystemSubmitDrawer/DatasetSelect.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/DatasetSelect.tsx
@@ -80,7 +80,7 @@ export function DatasetSelect({
 }
 
 function DatasetSelectLabel({ dataset }: { dataset: DatasetMetadata }) {
-  const { dataset_id, dataset_name, sub_dataset } = dataset;
+  const { dataset_name, sub_dataset } = dataset;
   return (
     <div style={{ display: "flex", justifyContent: "space-between" }}>
       <span>

--- a/frontend/src/components/useUser.tsx
+++ b/frontend/src/components/useUser.tsx
@@ -34,7 +34,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const redirectPageKey = `explainaboard_${env}_redirect`;
 
   const [jwt, setJwt] = useState(initJWT());
-  const [state, setState] = useState(LoginState.no);
+  const [state, setState] = useState(LoginState.loading);
   const [userInfo, setUserInfo] = useState<User>();
 
   function initJWT() {


### PR DESCRIPTION
front end-user authentication process:
```
if jwt in localStorage:
  jwt = localStorage.get('jwt')
  loginState = "loading"
  backendClient.configJWT(jwt)

if jwt:
  try:
    userInfo = GET /user
    loginState = "yes"
  except:  # if jwt expired, will return 401
    loginState = "expired"
    backendClient.clearJWT()
else:
  loginState = "no"
```