### PR TITLE
Frontend fixes

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -15,7 +15,7 @@ export interface Filter {
   task?: string;
   sortField: string;
   sortDir: "asc" | "desc";
-  split: string;
+  split: string | undefined;
 }
 
 interface Props {
@@ -119,6 +119,7 @@ export function SystemTableTools({
             value: opt,
             label: opt,
           }))}
+          value={value.split}
           placeholder="Dataset split"
           onChange={(value) => onChange({ split: value })}
           style={{ minWidth: "120px" }}

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -35,7 +35,7 @@ export function SystemsTable({
   const [taskFilter, setTaskFilter] = useState(initialTaskFilter);
   const [sortField, setSortField] = useState("created_at");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-  const [split, setSplit] = useState<string>("all");
+  const [split, setSplit] = useState<string | undefined>(undefined);
 
   // submit
   const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   initialTaskFilter?: string;
   dataset?: string;
   subdataset?: string;
+  datasetSplit?: string;
 }
 
 /** A table that lists all systems */
@@ -22,6 +23,7 @@ export function SystemsTable({
   initialTaskFilter,
   dataset,
   subdataset,
+  datasetSplit,
 }: Props) {
   const [pageState, setPageState] = useState(PageState.loading);
   const [page, setPage] = useState(0);
@@ -35,7 +37,7 @@ export function SystemsTable({
   const [taskFilter, setTaskFilter] = useState(initialTaskFilter);
   const [sortField, setSortField] = useState("created_at");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-  const [split, setSplit] = useState<string | undefined>(undefined);
+  const [split, setSplit] = useState<string | undefined>(datasetSplit);
 
   // submit
   const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -128,15 +128,29 @@ const columns: ColumnsType<DatasetMetadata> = [
   {
     dataIndex: "",
     title: "Leaderboard",
-    render: (_, record) => (
-      <Typography.Link href={""} target="_blank">
-        <Link
-          to={generateLeaderboardURL(record.dataset_name, record.sub_dataset)}
-        >
-          Leaderboard
-        </Link>
-      </Typography.Link>
-    ),
+    render: (_, record) => {
+      // every dataset leaderboard has an "all" split, which means allowing all possible splits
+      let splits: Array<string | undefined> = ["all"];
+      if (record.split !== undefined) {
+        splits = splits.concat(Object.keys(record.split));
+      }
+      return splits.map((split) => {
+        return (
+          <div key={split}>
+            <Link
+              to={generateLeaderboardURL(
+                record.dataset_name,
+                record.sub_dataset,
+                split
+              )}
+              component={Typography.Link}
+            >
+              {split}
+            </Link>
+          </div>
+        );
+      });
+    },
   },
   {
     dataIndex: "links",

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -20,6 +20,7 @@ export function LeaderboardPage() {
   const task = query.get("task") || undefined;
   const dataset = query.get("dataset") || undefined;
   const subdataset = query.get("subdataset") || undefined;
+  const split = query.get("split") || undefined;
 
   if (task || dataset || subdataset) {
     let title = "";
@@ -49,6 +50,7 @@ export function LeaderboardPage() {
             initialTaskFilter={task}
             dataset={dataset}
             subdataset={subdataset}
+            datasetSplit={split}
           />
         </div>
       </div>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -37,13 +37,17 @@ export function generateDataLabURL(datasetName: string): string {
 
 export function generateLeaderboardURL(
   dataset: string,
-  subdataset: string | undefined
+  subdataset: string | undefined,
+  split: string | undefined
 ): string {
-  const url = `/leaderboards?dataset=${dataset}`;
-  if (subdataset === undefined) {
-    return url;
+  let url = `/leaderboards?dataset=${dataset}`;
+  if (subdataset !== undefined) {
+    url = `${url}&subdataset=${subdataset}`;
   }
-  return `${url}&subdataset=${subdataset}`;
+  if (split !== undefined) {
+    url = `${url}&split=${split}`;
+  }
+  return url;
 }
 
 export * from "./typing_utils";


### PR DESCRIPTION
Fixed these issues:
#141
#138
#142 (I moved the "Click a bar..." instruction to the top of the page for better visibility, and the UI now scrolls to the bottom to show the example table every time a bar is clicked.)

Some limitations
- Selecting a different split in the leaderboard does not trigger a change in the url
- Some datasets have special splits (e.g. `adv_mtl` has an `MR_test` split and many more), and some have less than 3 splits (e.g. `cr` has only test and train). The selectable leaderboard split filter doesn't take these into account at the moment and only provides 4 hardcoded options: all, test, validation, train. However, it's possible to specify the split via URL, e.g. `/leaderboards?dataset=adv_mtl&split=MR_test`

<img width="1181" alt="Screen Shot 2022-05-10 at 10 57 01 PM" src="https://user-images.githubusercontent.com/30998659/167759845-f32775bd-e9f5-4d5f-8034-f576c4224de2.png">