### PR TITLE
Upgrades to sequence labeling example display

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -17,6 +17,7 @@ from explainaboard import (
     get_processor,
 )
 from explainaboard.processors.processor_registry import get_metric_list_for_processor
+from explainaboard.utils.serialization import general_to_dict
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBCollection, DBUtils
@@ -327,9 +328,9 @@ class SystemDBUtils:
                     db_name=DBUtils.SYSTEM_OUTPUT_DB, collection_name=str(system_db_id)
                 )
                 DBUtils.drop(output_collection)
-                DBUtils.insert_many(
-                    output_collection, list(system_output_data.samples), False, session
-                )
+                sample_list = [general_to_dict(v) for v in system_output_data.samples]
+                print(f"sample_list[0]={sample_list[0]}")
+                DBUtils.insert_many(output_collection, sample_list, False, session)
                 return system_db_id
 
             system_id = DBUtils.execute_transaction(db_operations)

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -329,7 +329,6 @@ class SystemDBUtils:
                 )
                 DBUtils.drop(output_collection)
                 sample_list = [general_to_dict(v) for v in system_output_data.samples]
-                print(f"sample_list[0]={sample_list[0]}")
                 DBUtils.insert_many(output_collection, sample_list, False, session)
                 return system_db_id
 

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -29,7 +29,7 @@ from explainaboard_web.impl.utils import (
 from explainaboard_web.models import (
     DatasetMetadata,
     System,
-    SystemCreateProps,
+    SystemMetadata,
     SystemOutput,
     SystemOutputProps,
     SystemOutputsReturn,
@@ -197,7 +197,7 @@ class SystemDBUtils:
 
     @staticmethod
     def create_system(
-        metadata: SystemCreateProps,
+        metadata: SystemMetadata,
         system_output: SystemOutputProps,
         custom_dataset: SystemOutputProps | None = None,
     ) -> System:

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -302,7 +302,9 @@ def systems_analyses_post(body: SystemsAnalysesBody):
         ).system_outputs
         # Note we are casting here, as SystemOutput.from_dict() actually just returns a
         # dict
-        system_outputs = [cast(dict, x) for x in system_outputs]
+        system_outputs = [
+            processor.deserialize_system_output(cast(dict, x)) for x in system_outputs
+        ]
 
         performance_over_bucket = processor.bucketing_samples(
             system_output_info,

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import binascii
-import dataclasses
 import os
 from functools import lru_cache
 from typing import Optional, cast
@@ -305,26 +304,12 @@ def systems_analyses_post(body: SystemsAnalysesBody):
         # dict
         system_outputs = [cast(dict, x) for x in system_outputs]
 
-        fine_grained_statistics = processor.get_fine_grained_statistics(
+        performance_over_bucket = processor.bucketing_samples(
             system_output_info,
             system_outputs,
             system.active_features,
             metric_stats,
         )
-        performance_over_bucket: dict = fine_grained_statistics.performance_over_bucket
-        # TODO This is a HACK. Should add proper to_dict methods in SDK
-        for feature, feature_dict in performance_over_bucket.items():
-            for bucket_key, bucket_performance in list(feature_dict.items()):
-                bucket_performance = dataclasses.asdict(bucket_performance)
-                new_bucket_key = [str(number) for number in bucket_key]
-                new_bucket_key_str = f"({', '.join(new_bucket_key)})"
-                bucket_performance["bucket_name"] = [
-                    str(num) for num in bucket_performance["bucket_name"]
-                ]
-                performance_over_bucket[feature][
-                    new_bucket_key_str
-                ] = bucket_performance
-                performance_over_bucket[feature].pop(bucket_key)
 
         single_analyses[system.system_id] = performance_over_bucket
 

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -8,7 +8,7 @@ Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
 pyjwt[crypto] == 2.3.0
-explainaboard == 0.9.5
+explainaboard == 0.10.0
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pre-commit
 marisa_trie

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -8,7 +8,7 @@ Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
 pyjwt[crypto] == 2.3.0
-explainaboard == 0.10.0
+explainaboard == 0.10.1
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pre-commit
 marisa_trie

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -30,7 +30,7 @@ function renderColInfo(
   });
 
   for (const col of colInfo) {
-    if (col["name"] == "id") {
+    if (col["name"] === "id") {
       continue;
     }
     const maxWidth = col["maxWidth"] !== undefined ? col["maxWidth"] : "170px";
@@ -247,14 +247,14 @@ export function AnalysisTable({
       { id: "hypothesis", name: "Hypothesis", maxWidth: "500px" },
     ];
     dataSource = specifyDataGeneric(systemOutputs, columns, colInfo);
-  } else if (task == "text-classification") {
+  } else if (task === "text-classification") {
     colInfo = [
       { id: "true_label", name: "True Label" },
       { id: "predicted_label", name: "Predicted Label" },
       { id: "text", name: "Text", maxWidth: "800px" },
     ];
     dataSource = specifyDataGeneric(systemOutputs, columns, colInfo);
-  } else if (task == "text-pair-classification") {
+  } else if (task === "text-pair-classification") {
     colInfo = [
       { id: "true_label", name: "True Label" },
       { id: "predicted_label", name: "Predicted Label" },

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -74,81 +74,65 @@ export function AnalysisTable({
   }, [systemID, outputIDString, page, pageSize]);
 
   const columns: ColumnsType<SystemOutput> = [];
-  let dataSource;
 
-  // task NER
-  if (task === "named-entity-recognition") {
-    for (const subFeatureName of Object.keys(outputIDs[0])) {
-      columns.push({
-        dataIndex: subFeatureName,
-        title: subFeatureName,
-        ellipsis: true,
-      });
+  // example ID
+  columns.push({
+    dataIndex: "id",
+    title: "ID",
+    fixed: "left",
+    render: (value) => (
+      <Typography.Paragraph copyable style={{ marginBottom: 0 }}>
+        {value}
+      </Typography.Paragraph>
+    ),
+  });
+
+  // other fields
+  if (systemOutputs.length == 0) {
+    return <div>No system outputs found.</div>;
+  }
+  const systemOutputFirst = systemOutputs[0];
+  for (const systemOutputKey of Object.keys(systemOutputFirst)) {
+    if (systemOutputKey === "id") {
+      continue;
     }
-    // TODO API request to retrieve text, should be done on every page change
-    dataSource = outputIDs.map(function (o) {
-      const output = o as { [key: string]: string };
-      return { ...output };
-    });
-
-    // other tasks
-  } else if (systemOutputs.length !== 0) {
-    // example ID
     columns.push({
-      dataIndex: "id",
-      title: "ID",
-      fixed: "left",
-      render: (value) => (
-        <Typography.Paragraph copyable style={{ marginBottom: 0 }}>
-          {value}
-        </Typography.Paragraph>
-      ),
-    });
-
-    // other fields
-    const systemOutputFirst = systemOutputs[0];
-    for (const systemOutputKey of Object.keys(systemOutputFirst)) {
-      if (systemOutputKey === "id") {
-        continue;
-      }
-      columns.push({
-        dataIndex: systemOutputKey,
-        title: systemOutputKey,
-        render: (value) =>
-          typeof value === "number" ? (
-            <div style={{ minWidth: "65px" }}>
-              <Tooltip title={value}>{Math.round(value * 1e6) / 1e6}</Tooltip>
-            </div>
-          ) : (
-            <Typography.Paragraph
-              ellipsis={{ rows: 3, tooltip: true, expandable: true }}
-              style={{ marginBottom: 0, minWidth: "80px", maxWidth: "170px" }}
-            >
-              {value}
-            </Typography.Paragraph>
-          ),
-      });
-    }
-    // clone the system output for modification
-    dataSource = systemOutputs.map(function (systemOutput) {
-      const processedSystemOutput = { ...systemOutput };
-      for (const [key, output] of Object.entries(systemOutput)) {
-        /*Task like QA have object output besides string and number.
-          For now we serialize the object to a displayable string.
-          TODO: unnest or use a nested table
-        */
-        if (typeof output === "object") {
-          const processedOutput = Object.entries(output)
-            .map(([subKey, subOutput]) => {
-              return `${subKey}: ${subOutput}`;
-            })
-            .join("\n");
-          processedSystemOutput[key] = processedOutput;
-        }
-      }
-      return processedSystemOutput;
+      dataIndex: systemOutputKey,
+      title: systemOutputKey,
+      render: (value) =>
+        typeof value === "number" ? (
+          <div style={{ minWidth: "65px" }}>
+            <Tooltip title={value}>{Math.round(value * 1e6) / 1e6}</Tooltip>
+          </div>
+        ) : (
+          <Typography.Paragraph
+            ellipsis={{ rows: 3, tooltip: true, expandable: true }}
+            style={{ marginBottom: 0, minWidth: "80px", maxWidth: "170px" }}
+          >
+            {value}
+          </Typography.Paragraph>
+        ),
     });
   }
+  // clone the system output for modification
+  const dataSource = systemOutputs.map(function (systemOutput) {
+    const processedSystemOutput = { ...systemOutput };
+    for (const [key, output] of Object.entries(systemOutput)) {
+      /*Task like QA have object output besides string and number.
+        For now we serialize the object to a displayable string.
+        TODO: unnest or use a nested table
+      */
+      if (typeof output === "object") {
+        const processedOutput = Object.entries(output)
+          .map(([subKey, subOutput]) => {
+            return `${subKey}: ${subOutput}`;
+          })
+          .join("\n");
+        processedSystemOutput[key] = processedOutput;
+      }
+    }
+    return processedSystemOutput;
+  });
 
   // TODO scroll to the bottom after rendered?
   return (

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -954,13 +954,7 @@ components:
       properties:
         sample_id:
           type: integer
-      additionalProperties:
-        type: string
-        properties:
-          code:
-            type: integer
-          text:
-            type: string
+      additionalProperties: true
 
     User:
       type: object

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.1.3"
+  version: "0.1.4"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -896,10 +896,12 @@ components:
     BucketPerformance:
       type: object
       properties:
-        bucket_name:
+        bucket_interval:
           type: array
           items:
-            type: string
+            oneOf:
+              - type: string
+              - type: number
         n_samples:
           type: number
         bucket_samples:
@@ -910,15 +912,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Performance"
-      required: [bucket_name, n_samples, bucket_samples, performances]
+      required: [bucket_interval, n_samples, bucket_samples, performances]
 
     SingleAnalysisReturn:
       type: object
       description: feature -> bucket interval
       additionalProperties:
-        type: object
-        description: bucket interval -> BucketPerformance
-        additionalProperties:
+        type: array
+        items:
           $ref: "#/components/schemas/BucketPerformance"
 
     SystemAnalysesReturn:
@@ -952,7 +953,7 @@ components:
       type: object
       properties:
         sample_id:
-          type: string
+          type: integer
       additionalProperties:
         type: string
         properties:


### PR DESCRIPTION
This somewhat improves the display of examples for sequence labeling tasks such as a NER. Here is an example of the new display:

<img width="1128" alt="Screen Shot 2022-05-23 at 8 52 04 AM" src="https://user-images.githubusercontent.com/398875/169770496-d56e0353-aeaa-4044-8e1d-5afc27eebf8a.png">

This is dependent on ExplainaBoard v0.10.0, so tests will fail until that is in pypi.

Fixes https://github.com/neulab/explainaboard_web/issues/96