### PR TITLE
bug fix for system_name in find_systems

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -132,7 +132,7 @@ class SystemDBUtils:
         if ids:
             filt["_id"] = {"$in": [ObjectId(_id) for _id in ids]}
         if system_name:
-            filt["system_name"] = {"$regex": rf"^{system_name}.*"}
+            filt["system_info.system_name"] = {"$regex": rf"^{system_name}.*"}
         if task:
             filt["system_info.task_name"] = task
         if dataset_name:


### PR DESCRIPTION
On line 135, changed to filt["system_info.system_name"] = {"$regex": rf"^{system_name}.*"} from filt["system_name"] = {"$regex": rf"^{system_name}.*"}