### PR TITLE
Fix bug in benchmarks

### DIFF
--- a/backend/src/impl/benchmark_configs/config_gaokao.json
+++ b/backend/src/impl/benchmark_configs/config_gaokao.json
@@ -1,4 +1,5 @@
 {
+    "id": "gaokao",
     "name": "Gaokao",
     "description":"Gaokao Benchmark",
     "logo":"https://explainaboard.s3.amazonaws.com/benchmarks/figures/gaokao.jpg",

--- a/backend/src/impl/benchmark_configs/config_masakhaner.json
+++ b/backend/src/impl/benchmark_configs/config_masakhaner.json
@@ -1,5 +1,7 @@
 {
+    "id": "masakhaner",
     "name": "MasakhaNER",
+    "description": "A benchmark for named entity recognition in African languages",
     "logo":"https://explainaboard.s3.amazonaws.com/benchmarks/figures/masakhane.png",
     "metrics": [{"name": "F1"}],
     "datasets": [

--- a/backend/src/impl/benchmark_configs/config_miniglue.json
+++ b/backend/src/impl/benchmark_configs/config_miniglue.json
@@ -1,4 +1,5 @@
 {
+  "id": "miniglue",
   "name": "miniGLUE",
   "description":"miniGLUE",
   "logo":"https://explainaboard.s3.amazonaws.com/benchmarks/figures/gaokao.jpg",

--- a/frontend/src/components/BenchmarkTable/index.tsx
+++ b/frontend/src/components/BenchmarkTable/index.tsx
@@ -2,11 +2,12 @@ import React, { useEffect, useState } from "react";
 import "./index.css";
 import { backendClient } from "../../clients";
 import { Benchmark, BenchmarkTableData } from "../../clients/openapi";
-import { Tabs, Spin } from "antd";
+import { Tabs, Spin, PageHeader } from "antd";
 import { ColumnsType } from "antd/es/table";
 import { TableView } from "./TableView";
 import { PageState } from "../../utils";
 import { generateLeaderboardURL } from "../../utils";
+import { useHistory } from "react-router-dom";
 
 interface Props {
   /**initial value for task filter */
@@ -29,7 +30,7 @@ function tableToPage(my_view: BenchmarkTableData) {
   );
   const view_name = my_view.name;
   return (
-    <TabPane tab={view_name + " view"} key={view_name}>
+    <TabPane tab={view_name} key={view_name}>
       <TableView view={view_name} columns={data_cols} dataSource={sys_data} />
     </TabPane>
   );
@@ -39,6 +40,7 @@ function tableToPage(my_view: BenchmarkTableData) {
 export function BenchmarkTable({ benchmarkID }: Props) {
   const [benchmark, setBenchmark] = useState<Benchmark>();
   const [pageState, setPageState] = useState(PageState.loading);
+  const history = useHistory();
 
   useEffect(() => {
     async function fetchBenchmark() {
@@ -67,15 +69,30 @@ export function BenchmarkTable({ benchmarkID }: Props) {
     }
     return (
       <div>
-        <p> {supportedDatasets}</p>
-        <Tabs>
-          {benchmark.views.map((my_view) => {
-            return tableToPage(my_view);
-          })}
-        </Tabs>
+        <PageHeader
+          title={benchmark.config.name + " Benchmark"}
+          subTitle={benchmark.config.description}
+          onBack={history.goBack}
+        />
+        <div style={{ padding: "10px 10px" }}>
+          <p> {supportedDatasets}</p>
+          <Tabs>
+            {benchmark.views.map((my_view) => {
+              return tableToPage(my_view);
+            })}
+          </Tabs>
+        </div>
       </div>
     );
   } else {
-    return <Spin spinning={pageState === PageState.loading} tip="Loading..." />;
+    return (
+      <div>
+        <PageHeader
+          title={benchmarkID + " Benchmark"}
+          onBack={history.goBack}
+        />
+        <Spin spinning={pageState === PageState.loading} tip="Loading..." />
+      </div>
+    );
   }
 }

--- a/frontend/src/pages/BenchmarkHome/index.tsx
+++ b/frontend/src/pages/BenchmarkHome/index.tsx
@@ -27,8 +27,8 @@ export function BenchmarkHome() {
         subTitle="All benchmarks"
       />
       <Row gutter={[16, 16]} className="benchmarks-grid">
-        {benchmarkConfigs.map(({ name, logo }) => (
-          <Col key={name} span={6}>
+        {benchmarkConfigs.map(({ id, name, logo }) => (
+          <Col key={id} span={6}>
             <Card
               hoverable
               style={{
@@ -42,7 +42,7 @@ export function BenchmarkHome() {
               }
               // title= {< div style= {{textAlign: "center"}} > Card title </div >}
               onClick={() =>
-                history.push(`${document.location.pathname}?name=${name}`)
+                history.push(`${document.location.pathname}?id=${id}`)
               }
               cover={<img alt="example" style={{ height: 200 }} src={logo} />}
             >

--- a/frontend/src/pages/BenchmarkPage/index.tsx
+++ b/frontend/src/pages/BenchmarkPage/index.tsx
@@ -1,17 +1,8 @@
 import React from "react";
 import "./index.css";
-import { PageHeader } from "antd";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { BenchmarkTable } from "../../components";
 import { BenchmarkHome } from "../BenchmarkHome";
-
-// useEffect(() => {
-//   async function fetchBenchmark() {
-//     const result = await backendClient.benchmarkBenchmarkIdGet(benchmarkID);
-//     setbenchmark(result);
-//   }
-//   fetchBenchmark();
-// }, [benchmarkID]);
 
 function useQuery() {
   const { search } = useLocation();
@@ -19,45 +10,11 @@ function useQuery() {
 }
 
 export function BenchmarkPage() {
-  const history = useHistory();
   const query = useQuery();
-  const name = query.get("name") || undefined;
+  const id = query.get("id") || undefined;
 
-  // const [benchmark, setbenchmark] = useState<Benchmark>();
-  // const [benchmarkID, setbenchmarkID] = useState<string>("");
-
-  // let bm_name = ""
-  // if (name){
-  //   bm_name = name
-  // }
-  // console.log("-------bm_name-----")
-  // console.log(bm_name)
-
-  // useEffect(() => {
-  //   async function fetchBenchmark() {
-  //     setbenchmark(await backendClient.benchmarkBenchmarkIdGet(benchmarkID));
-  //   }
-  //   fetchBenchmark();
-  // }, [benchmarkID]);
-
-  if (name) {
-    let title = "";
-    title = name;
-    let subTitle = "";
-    subTitle = `${name}`;
-
-    return (
-      <div>
-        <PageHeader
-          onBack={() => history.goBack()}
-          title={title + " Benchmark"}
-          subTitle={`Benchmark for ${subTitle}`}
-        />
-        <div style={{ padding: "0 10px" }}>
-          <BenchmarkTable benchmarkID={name} />
-        </div>
-      </div>
-    );
+  if (id) {
+    return <BenchmarkTable benchmarkID={id} />;
   } else {
     return <BenchmarkHome />;
   }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.1.5"
+  version: "0.1.6"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -1044,6 +1044,8 @@ components:
     BenchmarkConfig:
       type: object
       properties:
+        id:
+          type: string
         name:
           type: string
         description:


### PR DESCRIPTION
There was an issue on linux (but not my local dev environment) with using benchmark names for getting benchmark config files because the names were capitalized but the config files were not. This fixes the issue, and also decouples the benchmark name from the benchmark ID (which seems like a good idea in general, the name could contain spaces, etc., which makes things a bit thorny).