### PR TITLE
Made it possible to log signed-in users

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^12.20.27",
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
+        "@types/react-helmet": "^6.1.5",
         "@types/react-router-dom": "^5.3.0",
         "antd": "^4.17.0",
         "echarts": "^5.2.2",
@@ -26,6 +27,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-ga4": "^1.4.1",
+        "react-helmet": "^6.1.0",
         "react-router-dom": "^5.3.0",
         "typescript": "^4.4.3",
         "web-vitals": "^1.1.2"
@@ -3794,6 +3796,14 @@
       "version": "17.0.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
       "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-helmet": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.5.tgz",
+      "integrity": "sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -19385,10 +19395,29 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-ga4": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
       "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -19576,6 +19605,14 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -27742,6 +27779,14 @@
       "version": "17.0.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
       "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-helmet": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.5.tgz",
+      "integrity": "sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==",
       "requires": {
         "@types/react": "*"
       }
@@ -39985,10 +40030,26 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-ga4": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
       "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -40147,6 +40208,12 @@
           }
         }
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "rc-slider": "~10.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-ga4": "^1.4.1",
         "react-router-dom": "^5.3.0",
         "typescript": "^4.4.3",
         "web-vitals": "^1.1.2"
@@ -19383,6 +19384,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
+    },
+    "node_modules/react-ga4": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
+      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -39978,6 +39984,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
+    },
+    "react-ga4": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
+      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^12.20.27",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
+    "@types/react-helmet": "^6.1.5",
     "@types/react-router-dom": "^5.3.0",
     "antd": "^4.17.0",
     "echarts": "^5.2.2",
@@ -25,13 +26,14 @@
     "eslint": "^7.32.0",
     "isomorphic-fetch": "^3.0.0",
     "moment": "^2.29.1",
+    "rc-slider": "~10.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-ga4": "^1.4.1",
+    "react-helmet": "^6.1.0",
     "react-router-dom": "^5.3.0",
     "typescript": "^4.4.3",
-    "web-vitals": "^1.1.2",
-    "rc-slider": "~10.0.0"
+    "web-vitals": "^1.1.2"
   },
   "lint-staged": {
     "**/*": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "moment": "^2.29.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-ga4": "^1.4.1",
     "react-router-dom": "^5.3.0",
     "typescript": "^4.4.3",
     "web-vitals": "^1.1.2",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>ExplainaBoard For Natural Language Processing</title>
+    <title>ExplainaBoard - Explainable Leaderboards</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,20 +25,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>ExplainaBoard For Natural Language Processing</title>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-CG1YDJJKV1"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-81Z5VKS44V");
-    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/components/BenchmarkCards/index.tsx
+++ b/frontend/src/components/BenchmarkCards/index.tsx
@@ -3,6 +3,7 @@ import { useHistory } from "react-router-dom";
 import "./index.css";
 import { Card, Col, PageHeader, Row, Typography } from "antd";
 import { BenchmarkConfig } from "../../clients/openapi";
+import { Helmet } from "react-helmet";
 
 interface Props {
   items: Array<BenchmarkConfig>;
@@ -17,6 +18,9 @@ export function BenchmarkCards({ items, subtitle }: Props) {
 
   return (
     <div className="page">
+      <Helmet>
+        <title>ExplainaBoard - Datasets</title>
+      </Helmet>
       <PageHeader
         onBack={() => history.goBack()}
         title="Benchmarks"

--- a/frontend/src/components/BenchmarkTable/index.tsx
+++ b/frontend/src/components/BenchmarkTable/index.tsx
@@ -18,6 +18,7 @@ import { PageState } from "../../utils";
 import { generateLeaderboardURL } from "../../utils";
 import { useHistory, Link } from "react-router-dom";
 import { CheckSquareTwoTone } from "@ant-design/icons";
+import { Helmet } from "react-helmet";
 
 interface Props {
   /**initial value for task filter */
@@ -142,6 +143,9 @@ export function BenchmarkTable({ benchmarkID }: Props) {
     return (
       <div>
         <div style={{ padding: "10px 10px" }}>
+          <Helmet>
+            <title>ExplainaBoard - {benchmark.config.name} Benchmark</title>
+          </Helmet>
           <Descriptions
             title={<b style={{ fontSize: "30px" }}>{benchmark.config.name}</b>}
           >
@@ -275,10 +279,13 @@ export function BenchmarkTable({ benchmarkID }: Props) {
   } else {
     return (
       <div>
+        <Helmet>
+          <title>ExplainaBoard - {benchmarkID} Benchmark</title>
+        </Helmet>
         <PageHeader
           title={<b style={{ fontSize: "30px" }}>{benchmarkID} Benchmark</b>}
           onBack={history.goBack}
-        ></PageHeader>
+        />
         <Spin spinning={pageState === PageState.loading} tip="Loading..." />
       </div>
     );

--- a/frontend/src/components/useGoogleAnalytics.tsx
+++ b/frontend/src/components/useGoogleAnalytics.tsx
@@ -1,0 +1,26 @@
+import { LoginState, useUser } from ".";
+import { useHistory } from "react-router-dom";
+import ReactGA from "react-ga4";
+import { useState } from "react";
+
+export function useGoogleAnalytics() {
+  const { userInfo, state } = useUser();
+  const history = useHistory();
+
+  if (state !== LoginState.loading) {
+    // Set info for Google Analytics and share pageview
+    if (!ReactGA._hasLoadedGA) {
+      ReactGA.initialize("G-CG1YDJJKV1");
+
+      if (userInfo) {
+        ReactGA.set({ userId: userInfo.username });
+      }
+
+      ReactGA.send("pageview");
+
+      history.listen((location) => {
+        ReactGA.send("pageview");
+      });
+    }
+  }
+}

--- a/frontend/src/pages/BenchmarkPage/index.tsx
+++ b/frontend/src/pages/BenchmarkPage/index.tsx
@@ -5,6 +5,7 @@ import { BenchmarkTable } from "../../components";
 import { BenchmarkCards } from "../../components/BenchmarkCards";
 import { backendClient } from "../../clients";
 import { BenchmarkConfig } from "../../clients/openapi";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 function useQuery() {
   const { search } = useLocation();
@@ -12,6 +13,7 @@ function useQuery() {
 }
 
 export function BenchmarkPage() {
+  useGoogleAnalytics();
   const history = useHistory();
   const query = useQuery();
   const id = query.get("id") || "";

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -12,6 +12,7 @@ import {
 import { useHistory } from "react-router";
 import { Link } from "react-router-dom";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
+import { Helmet } from "react-helmet";
 
 /**
  * Dataset Page
@@ -63,6 +64,9 @@ export function DatasetsPage() {
           alignItems: "center",
         }}
       >
+        <Helmet>
+          <title>ExplainaBoard - Datasets</title>
+        </Helmet>
         <PageHeader
           onBack={() => history.goBack()}
           title="Datasets"

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../utils";
 import { useHistory } from "react-router";
 import { Link } from "react-router-dom";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 /**
  * Dataset Page
@@ -19,6 +20,7 @@ import { Link } from "react-router-dom";
  * 2. filter by task
  */
 export function DatasetsPage() {
+  useGoogleAnalytics();
   const [pageState, setPageState] = useState(PageState.loading);
   const [datasets, setDatasets] = useState<DatasetMetadata[]>([]);
   const [page, setPage] = useState(0);

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -2,8 +2,10 @@ import React from "react";
 
 import logo from "../../logo-full.png";
 import "./index.css";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 export function Home() {
+  useGoogleAnalytics();
   return (
     <div className="h-full flex items-center">
       <div

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -3,11 +3,15 @@ import React from "react";
 import logo from "../../logo-full.png";
 import "./index.css";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
+import { Helmet } from "react-helmet";
 
 export function Home() {
   useGoogleAnalytics();
   return (
     <div className="h-full flex items-center">
+      <Helmet>
+        <title>ExplainaBoard - Explainable Leaderboards</title>
+      </Helmet>
       <div
         className="w-full h-full bg-center bg-cover"
         style={{ backgroundImage: `url(${logo})` }}
@@ -15,9 +19,7 @@ export function Home() {
         <div className="w-full h-full bg-opacity-60 items-center flex">
           <div className="text-center ml-auto mr-auto">
             <h1 className="text-white text-6xl mb-0">ExplainaBoard</h1>
-            <p className="text-white text-2xl ">
-              An Explainable Leaderboard for NLP
-            </p>
+            <p className="text-white text-2xl ">Explainable Leaderboards</p>
             <div className="relative flex flex-col min-w-0 break-words bg-white py-3 mx-20 rounded-lg">
               <h2 className="text-3xl">Do you want to?</h2>
               <ul className="text-xl text-left mx-16">

--- a/frontend/src/pages/LeaderboardHome/index.tsx
+++ b/frontend/src/pages/LeaderboardHome/index.tsx
@@ -5,6 +5,7 @@ import { Collapse, Card, Col, PageHeader, Row, Space, Typography } from "antd";
 import { backendClient } from "../../clients";
 import { TaskCategory } from "../../clients/openapi";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
+import { Helmet } from "react-helmet";
 
 export function LeaderboardHome() {
   useGoogleAnalytics();
@@ -20,6 +21,9 @@ export function LeaderboardHome() {
 
   return (
     <div className="page">
+      <Helmet>
+        <title>ExplainaBoard - Leaderboards</title>
+      </Helmet>
       <PageHeader
         onBack={() => history.goBack()}
         title="Leaderboards"

--- a/frontend/src/pages/LeaderboardHome/index.tsx
+++ b/frontend/src/pages/LeaderboardHome/index.tsx
@@ -4,8 +4,10 @@ import "./index.css";
 import { Collapse, Card, Col, PageHeader, Row, Space, Typography } from "antd";
 import { backendClient } from "../../clients";
 import { TaskCategory } from "../../clients/openapi";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 export function LeaderboardHome() {
+  useGoogleAnalytics();
   const history = useHistory();
   const [taskCategories, setTaskCategories] = useState<TaskCategory[]>([]);
 

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from "antd";
 import { useHistory, useLocation } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import { LeaderboardHome } from "../LeaderboardHome";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 function useQuery() {
   const { search } = useLocation();
@@ -15,6 +16,7 @@ function useQuery() {
  * 1. handle task name not valid
  */
 export function LeaderboardPage() {
+  useGoogleAnalytics();
   const history = useHistory();
   const query = useQuery();
   const task = query.get("task") || undefined;

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -5,6 +5,7 @@ import { useHistory, useLocation } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import { LeaderboardHome } from "../LeaderboardHome";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
+import { Helmet } from "react-helmet";
 
 function useQuery() {
   const { search } = useLocation();
@@ -42,6 +43,9 @@ export function LeaderboardPage() {
     }
     return (
       <div>
+        <Helmet>
+          <title>ExplainaBoard - {title} Leaderboard</title>
+        </Helmet>
         <PageHeader
           onBack={() => history.goBack()}
           title={title + " Leaderboard"}

--- a/frontend/src/pages/SystemsPage/index.tsx
+++ b/frontend/src/pages/SystemsPage/index.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from "antd";
 import { useHistory, useLocation } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import "./index.css";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 function useQuery() {
   const { search } = useLocation();
@@ -13,6 +14,7 @@ function useQuery() {
  * Systems Page
  */
 export function SystemsPage() {
+  useGoogleAnalytics();
   const history = useHistory();
   const query = useQuery();
   const system = query.get("system") || undefined;

--- a/frontend/src/pages/SystemsPage/index.tsx
+++ b/frontend/src/pages/SystemsPage/index.tsx
@@ -4,6 +4,7 @@ import { useHistory, useLocation } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import "./index.css";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
+import { Helmet } from "react-helmet";
 
 function useQuery() {
   const { search } = useLocation();
@@ -22,6 +23,9 @@ export function SystemsPage() {
   if (system) {
     return (
       <div className="page">
+        <Helmet>
+          <title>ExplainaBoard - Systems</title>
+        </Helmet>
         <PageHeader
           onBack={() => history.goBack()}
           title="Systems"
@@ -34,6 +38,9 @@ export function SystemsPage() {
   } else {
     return (
       <div className="page">
+        <Helmet>
+          <title>ExplainaBoard - Systems</title>
+        </Helmet>
         <PageHeader
           onBack={() => history.goBack()}
           title="Systems"

--- a/frontend/src/pages/TermsPage/index.tsx
+++ b/frontend/src/pages/TermsPage/index.tsx
@@ -3,11 +3,15 @@ import React from "react";
 import logo from "../../logo-full.png";
 import "./index.css";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
+import { Helmet } from "react-helmet";
 
 export function TermsPage() {
   useGoogleAnalytics();
   return (
     <div className="h-full flex items-center">
+      <Helmet>
+        <title>ExplainaBoard - Terms</title>
+      </Helmet>
       <div
         className="w-full h-full bg-center bg-cover"
         style={{ backgroundImage: `url(${logo})` }}

--- a/frontend/src/pages/TermsPage/index.tsx
+++ b/frontend/src/pages/TermsPage/index.tsx
@@ -2,8 +2,10 @@ import React from "react";
 
 import logo from "../../logo-full.png";
 import "./index.css";
+import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 
 export function TermsPage() {
+  useGoogleAnalytics();
   return (
     <div className="h-full flex items-center">
       <div


### PR DESCRIPTION
This PR refactors logging with Google Analytics to:

1. Keep track of user sign-ins
2. Log when people switch from page-to-page
3. Change page title appropriately

Fixes https://github.com/neulab/explainaboard_web/issues/220