### PR TITLE
Fix typo on benchmarks page

### DIFF
--- a/frontend/src/components/BenchmarkCards/index.tsx
+++ b/frontend/src/components/BenchmarkCards/index.tsx
@@ -19,7 +19,7 @@ export function BenchmarkCards({ items, subtitle }: Props) {
   return (
     <div className="page">
       <Helmet>
-        <title>ExplainaBoard - Datasets</title>
+        <title>ExplainaBoard - Benchmarks</title>
       </Helmet>
       <PageHeader
         onBack={() => history.goBack()}


### PR DESCRIPTION
This is trivial so I'll just merge it myself.