### PR TITLE
Upgrade metrics to work w/ ExplainaBoard 0.10.4

### DIFF
--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -15,7 +15,7 @@ from explainaboard import metric as exb_metric
 from explainaboard.feature import FeatureType
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.loader_registry import get_supported_file_types_for_loader
-from explainaboard.metric import MetricStats
+from explainaboard.metrics.metric import MetricStats
 from explainaboard.processors.processor_registry import get_metric_list_for_processor
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.benchmark_utils import BenchmarkUtils

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -11,11 +11,11 @@ from explainaboard import (
     get_processor,
     get_task_categories,
 )
-from explainaboard import metric as exb_metric
 from explainaboard.feature import FeatureType
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.loader_registry import get_supported_file_types_for_loader
 from explainaboard.metrics.metric import MetricStats
+from explainaboard.metrics.registry import metric_name_to_config_class
 from explainaboard.processors.processor_registry import get_metric_list_for_processor
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.benchmark_utils import BenchmarkUtils
@@ -333,7 +333,9 @@ def systems_analyses_post(body: SystemsAnalysesBody):
             system_output_info.features[feature_name] = feature
 
         metric_configs = [
-            getattr(exb_metric, metric_config_dict["cls_name"])(**metric_config_dict)
+            metric_name_to_config_class(metric_config_dict["cls_name"])(
+                **metric_config_dict
+            )
             for metric_config_dict in system_output_info.metric_configs
         ]
 

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -8,7 +8,7 @@ Flask-PyMongo
 swagger-ui-bundle >= 0.0.9
 python-dotenv
 pyjwt[crypto] == 2.3.0
-explainaboard == 0.10.2
+explainaboard == 0.10.4
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
 pre-commit
 marisa_trie


### PR DESCRIPTION
There was a change in the metric interface and this commit catches up to this change.