### PR TITLE
More descriptive error on missing language in benchmark

### DIFF
--- a/backend/src/impl/benchmark_utils.py
+++ b/backend/src/impl/benchmark_utils.py
@@ -213,8 +213,12 @@ class BenchmarkUtils:
                         elif df_key == "dataset_split":
                             info = "test"
                         elif df_key == "source_language":
+                            if len(dataset_metadata.languages) == 0:
+                                raise ValueError(f"no {df_key} in {dataset_metadata}")
                             info = dataset_metadata.languages[0]
                         elif df_key == "target_language":
+                            if len(dataset_metadata.languages) == 0:
+                                raise ValueError(f"no {df_key} in {dataset_metadata}")
                             info = dataset_metadata.languages[-1]
                         else:
                             raise ValueError(f"could not find information for {df_key}")


### PR DESCRIPTION
This gives a more descriptive error when a benchmark fails due to missing a language.