### PR TITLE
Implements custom features by dataset

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -325,6 +325,9 @@ class SystemDBUtils:
                         400, f"{metric_name} is not a supported metric"
                     )
                 metric_configs.append(metrics_lookup[metric_name])
+            custom_features = DatasetDBUtils.get_combined_custom_features(
+                system.dataset.dataset_id, system_output_data.metadata.custom_features
+            )
             processor_metadata = {
                 **metadata.to_dict(),
                 "dataset_name": system.dataset.dataset_name if system.dataset else None,
@@ -334,7 +337,7 @@ class SystemDBUtils:
                 "dataset_split": metadata.dataset_split,
                 "task_name": metadata.task,
                 "metric_configs": metric_configs,
-                "custom_features": system_output_data.metadata.custom_features,
+                "custom_features": custom_features,
             }
 
             return processor.get_overall_statistics(

--- a/backend/src/impl/general_configs/dataset_custom_features.json
+++ b/backend/src/impl/general_configs/dataset_custom_features.json
@@ -1,0 +1,9 @@
+{
+  "sst2": {
+    "true_label": {
+      "dtype": "string",
+      "description": "the true label",
+      "num_buckets": 10
+    }
+  }
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -897,6 +897,8 @@ components:
         huggingface_link:
           type: string
           format: url
+        custom_features:
+          type: object
       required:
         - dataset_id
         - dataset_name


### PR DESCRIPTION
This PR implements the ability to add custom features by dataset.

This is done by adding a specification to `backend/src/impl/general_configs/dataset_custom_features.json`. Right now I added a simple example for `sst2`, where the `true_label` field is used as a custom feature, but I intend to add a more realistic example for the `sumeval` workshop data soon.