### PR TITLE
replace flask dev server with gunicorn in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y default-jre wget
 RUN mkdir ./frontend
 COPY ./frontend/package.json ./frontend/package-lock.json ./frontend/
 WORKDIR /app/frontend
-RUN npm install -g npm@latest
+RUN npm install -g npm@8.5.4
 RUN npm install
 
 WORKDIR /app

--- a/backend/templates/__main__.mustache
+++ b/backend/templates/__main__.mustache
@@ -3,6 +3,7 @@ import os
 from explainaboard_web.impl.config import ProductionConfig, StagingConfig, LocalDevelopmentConfig
 from {{packageName}} import encoder
 
+
 # Custom Middleware for CORS headers
 # reference: https://github.com/zalando/connexion/issues/357
 class CorsHeaderMiddleware(object):
@@ -16,13 +17,14 @@ class CorsHeaderMiddleware(object):
 
         return self.app(environ, custom_start_response)
 
-def main():
+
+def create_app():
     app = connexion.App(__name__, specification_dir='./swagger/')
     app.app.json_encoder = encoder.JSONEncoder
     app.add_api('swagger.yaml', arguments={'title': '{{appName}}'},
                     pythonic_params=True, validate_responses=True)
     app.app.wsgi_app = CorsHeaderMiddleware(app.app.wsgi_app)
-   
+
     FLASK_ENV = os.getenv('FLASK_ENV')
     if FLASK_ENV == 'production':
         app.app.config.from_object(ProductionConfig())
@@ -30,9 +32,9 @@ def main():
         app.app.config.from_object(LocalDevelopmentConfig())
     elif FLASK_ENV == 'staging':
         app.app.config.from_object(StagingConfig())
-    
-    app.run(port={{serverPort}})
+
+    return app
 
 
 if __name__ == '__main__':
-    main()
+    create_app().run(port={{serverPort}})

--- a/deployment/serve.sh
+++ b/deployment/serve.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Starts nginx and gunicorn. It is meant for the explainaboard_web
+# container only. The script takes any number of gunicorn arguments
+# passed in as a string. 
+
+nohup nginx -g "daemon off;" & gunicorn -b 0.0.0.0:5000 "explainaboard_web.__main__:create_app()" $1

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start-backend:prod": "cd backend/src/gen && FLASK_ENV=production python -m explainaboard_web",
     "gen-api-code": "bash openapi/gen_api_layer.sh project",
     "setup": "npm install && npm run gen-api-code && pip install -r backend/src/gen/requirements.txt && npm --prefix frontend install",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build-image": "docker build . --platform amd64 --tag \"explainaboard_web:latest\"",
+    "run-container": "DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -p 80:80/tcp explainaboard_web"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes #52 
We have been using the Flask dev server in production which is single core (<- I think) and insecure. I replaced it with gunicorn in this PR.

- Logs: (using gunicorn's default behavior for now)
    - Errors: -> stderr so we'll still get errors logs in CoudWatch. 
    - Access Log: not captured so we'll lose access log in CloudWatch. I don't think we really need access logs so this is probably OK.
    - Logs from EB SDK: -> stdout so we still have those in CloudWatch, same applies to any manually added logs (e.g `logging.info()` etc)
- Load tests: I did some simple load tests using **locust**. The script I used basically swamps **/api/tasks**. I picked the simplest endpoint so it tests the performance of the server only. These results are not accurate (didn't run them multiple times, didn't know which core docker engine chose for those tests on M1, etc) but it is evident that gunicorn can help us achieve higher QPS with multiple workers.
    - Flask server on M1 Pro: max QPS = 3.7
    - gunicorn single worker on M1 Pro: max QPS = 3.9
    - gunicorn 3 workers on M1 Pro: max QPS = 11
    - Flask server in our current staging environment: max QPS = 5