### PR TITLE
handle custom dataset when retrieving dataset custom features

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -356,12 +356,13 @@ class SystemDBUtils:
 
         try:
             # -- find the dataset and grab custom features if they exist
-            dataset_info = DatasetDBUtils.find_dataset_by_id(system.dataset.dataset_id)
-            dataset_custom_features: dict = (
-                dict(dataset_info.custom_features)
-                if dataset_info and dataset_info.custom_features
-                else {}
-            )
+            dataset_custom_features = {}
+            if system.dataset:
+                dataset_info = DatasetDBUtils.find_dataset_by_id(
+                    system.dataset.dataset_id
+                )
+                if dataset_info and dataset_info.custom_features:
+                    dataset_custom_features = dict(dataset_info.custom_features)
 
             # -- load the system output into memory from the uploaded file(s)
             system_output_data = SystemDBUtils._load_sys_output(


### PR DESCRIPTION
@qjiang002 found this bug while she was testing the platform.

System submission is failing for custom datasets because our code doesn't do a null check for `dataset` (`dataset` is an optional property of `System`) before accessing its properties. This PR fixes this bug. This is also related to a broader issue #273 .