### PR TITLE
Replace get_metric_list_for_processor with get_processor and full_metric_list

### DIFF
--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -14,7 +14,6 @@ from explainaboard.analysis.case import AnalysisCase
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders import get_loader_class
 from explainaboard.metrics.metric import MetricStats
-from explainaboard.processors.processor_registry import get_metric_list_for_processor
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.serialization import general_to_dict
 from explainaboard.utils.typing_utils import narrow
@@ -90,7 +89,7 @@ def tasks_get() -> list[TaskCategory]:
             loader_class = get_loader_class(_task.name)
             supported_formats = loader_class.supported_file_types()
             supported_metrics = [
-                metric.name for metric in get_metric_list_for_processor(_task.name)
+                metric.name for metric in get_processor(_task.name).full_metric_list()
             ]
             tasks.append(
                 Task(


### PR DESCRIPTION
Explainaboard's `processor_registry.get_metric_list_for_processor` is a shorthand of `get_processor` and Processor's classmethod, `full_metric_list`. For Explainaboard, it is better to tighten APIs to expose outside of the repository. For Explainaboard web, it is better to use `get_processor` which is [explicitly exported](https://github.com/tetsuok/ExplainaBoard/blob/6a85d3c51fd1f8eca8ddfdcba11d59181a183781/explainaboard/__init__.py#L4) instead of using the function which is not explicitly exported.

Context: neulab/ExplainaBoard#432