### PR TITLE
fix: no longer accept all origins

### DIFF
--- a/backend/templates/__main__.mustache
+++ b/backend/templates/__main__.mustache
@@ -3,27 +3,11 @@ import os
 from explainaboard_web.impl.config import ProductionConfig, StagingConfig, LocalDevelopmentConfig
 from {{packageName}} import encoder
 
-
-# Custom Middleware for CORS headers
-# reference: https://github.com/zalando/connexion/issues/357
-class CorsHeaderMiddleware(object):
-    def __init__(self, app):
-        self.app = app
-
-    def __call__(self, environ, start_response):
-        def custom_start_response(status, headers, exc_info=None):
-            headers.append(('Access-Control-Allow-Origin', '*'))
-            return start_response(status, headers, exc_info)
-
-        return self.app(environ, custom_start_response)
-
-
 def create_app():
     app = connexion.App(__name__, specification_dir='./swagger/')
     app.app.json_encoder = encoder.JSONEncoder
     app.add_api('swagger.yaml', arguments={'title': '{{appName}}'},
                     pythonic_params=True, validate_responses=True)
-    app.app.wsgi_app = CorsHeaderMiddleware(app.app.wsgi_app)
 
     FLASK_ENV = os.getenv('FLASK_ENV')
     if FLASK_ENV == 'production':


### PR DESCRIPTION
No cors issues when running locally after the change. Sending request directly to backend will now be blocked. 
This is tested by changing the config in `frontend/src/clients/index.ts` to send requests directly to backend.

Also tested running in a docker image. Some apis worked, others didn't (because some database errors at the backend, 
which shouldn't be related to cors policy).