### PR TITLE
fix: tokenizer schema in openapi

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -652,17 +652,9 @@ components:
           items:
             $ref: "#/components/schemas/Analysis"
         source_tokenizer:
-          type: object
-          properties:
-            cls_name:
-              type: string
-              example: "SingleSpaceTokenizer"
+          $ref: "#/components/schemas/Tokenizer"
         target_tokenizer:
-          type: object
-          properties:
-            cls_name:
-              type: string
-              example: "SingleSpaceTokenizer"
+          $ref: "#/components/schemas/Tokenizer"
         results:
           type: object
           properties:
@@ -690,6 +682,16 @@ components:
           analyses,
           results,
         ]
+
+    Tokenizer:
+      type: object
+      properties:
+        cls_name:
+          type: string
+          example: "SingleSpaceTokenizer"
+        variety:
+          type: string
+          example: "intl"
 
     APIError:
       type: object


### PR DESCRIPTION
⚠️ Merger after #287 
In the latest SDK, serialization of `SacreBleuTokenizer ` contains a `variety` field ([code](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/utils/tokenizer.py#L252)). The field is not specified in `openapi.yaml` and hence is removed when saving to the DB, causing `KeyError` when deserializing.