### PR TITLE
better error msg for https

### DIFF
--- a/frontend/src/clients/index.ts
+++ b/frontend/src/clients/index.ts
@@ -35,8 +35,11 @@ export class BackendError implements APIError {
     public detail: string
   ) {}
   getErrorMsg() {
-    const errorCodeMsg = this.error_code === -1 ? "" : `: ${this.error_code}`;
-    return `[${this.response.statusText}${errorCodeMsg}] ${this.detail}`;
+    const errorCodeMsg =
+      this.error_code == null || this.error_code === -1
+        ? ""
+        : `: ${this.error_code}`;
+    return `[${this.response.status}${errorCodeMsg}] ${this.detail}`;
   }
 }
 /** Parse fetch error response into a `BackendError` */


### PR DESCRIPTION
The error messages on the UI for 500-type responses are quite confusing.

Before the change, error messages look like this in production:
> [: undefined] The server encountered an internal error and was unable to ...

Now, it becomes:
> [500] The server encountered an internal error and was unable to ...

I made two changes:
  - `statusText` is not available in production so I replaced it with `status`. ([relevant discussion](https://stackoverflow.com/questions/41632077/why-is-the-statustext-of-my-xhr-empty)).
  - There's no custom error code (`undefined`) if it's a 500-type response so I added code to handle it properly (by omitting the custom error code). 