### PR TITLE
Compress data using zlib during binarization and unbinarization

### DIFF
--- a/backend/src/impl/utils.py
+++ b/backend/src/impl/utils.py
@@ -1,5 +1,6 @@
 import base64
 import pickle
+import zlib
 from typing import Any
 
 from bson.binary import Binary
@@ -28,9 +29,10 @@ def decode_base64(encoded: str) -> str:
 
 # TODO(chihhao) consider moving to SDK?
 def binarize_bson(data: Any) -> Binary:
-    """convert data to BSON binary data"""
-    return Binary(pickle.dumps(data, protocol=2))
+    """convert and compress data to BSON binary data"""
+    return Binary(zlib.compress(pickle.dumps(data, protocol=2)))
 
 
 def unbinarize_bson(data: Binary) -> Any:
-    return pickle.loads(data)
+    """decompress and convert BSON binary data to Python objects"""
+    return pickle.loads(zlib.decompress(data))


### PR DESCRIPTION
⚠️ Merging this PR will cause previous systems submissions to break as their `metric_stats` are not compressed!
 
Similar to the motivation of #291. In addition, this fixes document too large error for system outputs with a large number of records. 

E.g., I was faced with a document too large error (38MB > limit 16MB) when submitting the full system output for CNN Daily Mail validation set (13368 records). The main cause is token-level analysis’s `metrics_stats` being too large (accounting for ~37MB), and `zlib.compress()` is able to reduce it to 0.4MB.