### PR TITLE
Refactor analysis drawer

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/AnalysisButton.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/AnalysisButton.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Button, ButtonProps, Tooltip } from "antd";
+import { RedoOutlined } from "@ant-design/icons";
+
+export function AnalysisButton(props: ButtonProps) {
+  return (
+    <Tooltip
+      title={
+        <div>
+          Adding, removing, or changing the right bounds of any graph enables
+          this button. Click it to update the analysis results.
+        </div>
+      }
+      placement="bottom"
+      color="white"
+      overlayInnerStyle={{ color: "black" }}
+    >
+      <Button icon={<RedoOutlined />} type="primary" {...props}>
+        Update analysis
+      </Button>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/Analysis/AnalysisDrawer/FallbackUI.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/FallbackUI.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Typography } from "antd";
+
+export function FallbackUI({ errorMessage }: { errorMessage?: string }) {
+  return (
+    <Typography.Text>
+      <Typography.Paragraph>
+        An error occurred in the analysis.
+      </Typography.Paragraph>
+      <Typography.Paragraph>
+        {errorMessage ||
+          "If you are doing a pair-wise analysis, double check if the selected systems use the same dataset."}
+      </Typography.Paragraph>
+      If you found a bug, kindly open an issue on{" "}
+      <Typography.Link
+        href="https://github.com/neulab/explainaboard_web"
+        target="_blank"
+      >
+        our GitHub repo
+      </Typography.Link>
+      . Thanks!
+    </Typography.Text>
+  );
+}

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -58,10 +58,10 @@ export function formatBucketName(unformattedName: Array<number>): string {
   }
 }
 
-// Parses features according to task type.
+/**
+ * Parses features according to task type.
+ */
 export function parse(
-  systemID: string,
-  task: string,
   bucketPerformances: AnalysisResult[],
   bucketType: string,
   levelName: string,
@@ -135,40 +135,15 @@ export function parse(
   return parsedResult;
 }
 
-// TODO(gneubig): can probably be deleted
-// export function findFeature(
-//   features: { [key: string]: unknown },
-//   name: string
-// ): SystemInfoFeature | undefined {
-//   if (name in features) {
-//     return features[name] as SystemInfoFeature;
-//   } else {
-//     for (const key in features) {
-//       if (typeof features[key] === "object" && features[key] !== null) {
-//         const val = findFeature(
-//           features[key] as { [key: string]: unknown },
-//           name
-//         );
-//         if (val !== undefined) {
-//           return val;
-//         }
-//       }
-//     }
-//   }
-//   return undefined;
-// }
-
+/**
+ * Takes in a task, metric names, and systems, and returns fine-grained evaluation
+ * results that can be accessed in the format:
+ * > value[metric_name : string][analysis_name : int][system_id : int]
+ */
 export function parseFineGrainedResults(
-  task: string,
   systems: SystemModel[],
   singleAnalyses: SingleAnalysis[]
 ): { [metric: string]: { [feature: string]: ResultFineGrainedParsed[] } } {
-  /**
-   * Takes in a task, metric names, and systems, and returns fine-grained evaluation
-   * results that can be accessed in the format:
-   * > value[metric_name : string][analysis_name : int][system_id : int]
-   */
-
   const parsedResults: {
     [metric: string]: {
       [analysis: string]: ResultFineGrainedParsed[];
@@ -200,8 +175,6 @@ export function parseFineGrainedResults(
 
       const metricToParsed: { [metric: string]: ResultFineGrainedParsed } =
         parse(
-          system.system_id,
-          task,
           analysisBuckets,
           bucketType,
           myResult.level,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -187,10 +187,10 @@ export function SystemsTable({
         setActiveSystemIDs={setActiveSystemIDs}
       />
       <AnalysisDrawer
-        visible={activeSystemIDs.length !== 0}
-        systems={systems}
-        activeSystemIDs={activeSystemIDs}
-        setActiveSystemIDs={setActiveSystemIDs}
+        systems={systems.filter((sys) =>
+          activeSystemIDs.includes(sys.system_id)
+        )}
+        closeDrawer={() => setActiveSystemIDs([])}
       />
       <SystemSubmitDrawer
         visible={submitDrawerVisible}


### PR DESCRIPTION
refactors `AnalysisDrawer` to make it a little easier to read
- props: 
    - removed `visible`: it can be derived by checking the length of `systems`.
    - removed `activeSystemIDs`: the concept of **active** system IDs is irrelevant to this component. This component should just take in a list of `systems` that it needs to display.
    - replaced `setActiveSystemIDs` with `closeDrawer`: similar to the above one. This component only needs to know how to close itself. It doesn't need to be able to set active system IDs to arbitrary values.
- states:
    - removed `systemAnalyses` and `significanceTestInfos`: both of them can be derived from `systemAnalysesReturn`. If we keep them as separate states, we need to make sure they are always updated simultaneously. It'll be easier to maintain if we have one source of truth and derive the properties we need from that source of truth.
    - removed `task` for the same reason
- moved `FallbackUI` and `AnalysisButton` to separate files
- small UI enhancements like positioning the spinner at a better height when no content is present