### PR TITLE
Add installation steps and dependencies in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
        
 3. Generate code for API layer
    - Run `npm run gen-api-code` to generate code for api layer (both server and client). Please remember to run this whenever open API definition changes.
+     - We assume your computer already has `wget` and `realpath` command installed. If not found, please install by:
+       - for `wget`
+         - MacOS Users: `brew install wget`
+         - Ubuntu Users: `sudo apt-get install wget` 
+       - for `realpath`
+         - MacOS Users: `brew install coreutils`
+         - Ubuntu Users: `sudo apt-get install coreutils` 
 
 4.  Setup dev environment for the frontend
     1. Install project dependencies `npm install`

--- a/backend/templates/requirements.mustache
+++ b/backend/templates/requirements.mustache
@@ -13,3 +13,5 @@ en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_co
 pre-commit
 marisa_trie
 sacrebleu[ja]
+six
+pandas

--- a/openapi/gen_api_layer.sh
+++ b/openapi/gen_api_layer.sh
@@ -1,6 +1,9 @@
 # Generates API layer code for backend and frontend based on openapi.yaml
 # reference: https://stackoverflow.com/a/47554626
 
+# abort the script if any errors occur
+set -e
+
 # three modes: generate frontend only, backend only and both
 mode=$1
 script_dir=`dirname "$(realpath $0)"`


### PR DESCRIPTION
Closes #272 

This PR modifies two places:

- In `README.md`, add installation instructions for people who are missing commands
- In requirements, add missing dependencies (`six` and `pandas`)