### PR TITLE
add toggle between my systems and all systems

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -193,7 +193,13 @@ export function SystemTableTools({
   const { state } = useUser();
   const loggedIn = state === LoginState.yes;
 
-  // showMine radio button options
+  /**
+   * showMine radio buttion options.
+   * There are two labels, `My systems` and `All systems`. If `My systems` 
+   * is clicked, value is set to `true` for `showMine`. Otherwise, false.
+   * 
+   * If the user is not logged in, `My Systems` option would be disabled.
+   */
   const showMineOptions = [
     { label: "My Systems", value: true, disabled: !loggedIn },
     { label: "All Systems", value: false },

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -190,11 +190,40 @@ export function SystemTableTools({
     }
   }
 
+  let loggedIn = false;
+  const { state } = useUser();
+  if (state === LoginState.yes) {
+    loggedIn = true;
+  }
+
   // showMine radio button options
   const showMineOptions = [
-    { label: "My Systems", value: true },
+    { label: "My Systems", value: true, disabled: !loggedIn },
     { label: "All Systems", value: false },
   ];
+
+  let mineVsAllSystemsToggle = (
+    <Radio.Group
+      options={showMineOptions}
+      onChange={({ target: { value } }) => onChange({ showMine: value })}
+      value={value.showMine}
+      optionType="button"
+      buttonStyle="solid"
+    />
+  );
+
+  // add "remind log in pop up" if not logged in
+  if (!loggedIn) {
+    const remindLogInMessage = (
+      <div>
+        <p>Please log in to see your own systems.</p>
+      </div>
+    );
+
+    mineVsAllSystemsToggle = (
+      <Tooltip title={remindLogInMessage}>{mineVsAllSystemsToggle}</Tooltip>
+    );
+  }
 
   return (
     <div style={{ width: "100%" }}>
@@ -205,13 +234,16 @@ export function SystemTableTools({
         {deleteButton}
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
-        <Radio.Group
-          options={showMineOptions}
-          onChange={({ target: { value } }) => onChange({ showMine: value })}
-          value={value.showMine}
-          optionType="button"
-          buttonStyle="solid"
-        />
+        {mineVsAllSystemsToggle}
+        {/* <Tooltip title={remindLogInMessage}>
+          <Radio.Group
+            options={showMineOptions}
+            onChange={({ target: { value } }) => onChange({ showMine: value })}
+            value={value.showMine}
+            optionType="button"
+            buttonStyle="solid"
+          />
+        </Tooltip> */}
         <Select
           options={["test", "validation", "train", "all"].map((opt) => ({
             value: opt,

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   message,
   Popconfirm,
+  Radio,
 } from "antd";
 import { TaskSelect } from "..";
 import { TaskCategory } from "../../clients/openapi";
@@ -22,6 +23,7 @@ import { backendClient, parseBackendError } from "../../clients";
 export interface Filter {
   name?: string;
   task?: string;
+  showMine: boolean;
   sortField: string;
   sortDir: "asc" | "desc";
   split: string | undefined;
@@ -188,6 +190,12 @@ export function SystemTableTools({
     }
   }
 
+  // showMine radio button options
+  const showMineOptions = [
+    { label: "My Systems", value: true },
+    { label: "All Systems", value: false },
+  ];
+
   return (
     <div style={{ width: "100%" }}>
       <Space style={{ width: "fit-content", float: "left" }}>
@@ -197,6 +205,13 @@ export function SystemTableTools({
         {deleteButton}
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
+        <Radio.Group
+          options={showMineOptions}
+          onChange={({ target: { value } }) => onChange({ showMine: value })}
+          value={value.showMine}
+          optionType="button"
+          buttonStyle="solid"
+        />
         <Select
           options={["test", "validation", "train", "all"].map((opt) => ({
             value: opt,

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -190,11 +190,8 @@ export function SystemTableTools({
     }
   }
 
-  let loggedIn = false;
   const { state } = useUser();
-  if (state === LoginState.yes) {
-    loggedIn = true;
-  }
+  const loggedIn = state === LoginState.yes;
 
   // showMine radio button options
   const showMineOptions = [
@@ -235,15 +232,6 @@ export function SystemTableTools({
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
         {mineVsAllSystemsToggle}
-        {/* <Tooltip title={remindLogInMessage}>
-          <Radio.Group
-            options={showMineOptions}
-            onChange={({ target: { value } }) => onChange({ showMine: value })}
-            value={value.showMine}
-            optionType="button"
-            buttonStyle="solid"
-          />
-        </Tooltip> */}
         <Select
           options={["test", "validation", "train", "all"].map((opt) => ({
             value: opt,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -37,6 +37,7 @@ export function SystemsTable({
   // filters
   const [nameFilter, setNameFilter] = useState(name);
   const [taskFilter, setTaskFilter] = useState(initialTaskFilter);
+  const [showMine, setShowMine] = useState(false);
   const [sortField, setSortField] = useState("created_at");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   const [split, setSplit] = useState<string | undefined>(datasetSplit);
@@ -54,7 +55,8 @@ export function SystemsTable({
   // systems to be analyzed
   const [activeSystemIDs, setActiveSystemIDs] = useState<string[]>([]);
 
-  const { state: loginState } = useUser();
+  const { state: loginState, userInfo } = useUser();
+  const userEmail = userInfo?.email;
 
   /** generate metrics options list */
   function getMetricsNames() {
@@ -95,6 +97,8 @@ export function SystemsTable({
     async function refreshSystems() {
       setPageState(PageState.loading);
       const datasetSplit = split === "all" ? undefined : split;
+      // FIXME: this is hardcoded
+      const creator = showMine === true ? userEmail : "";
       try {
         const { systems: newSystems, total: newTotal } =
           await backendClient.systemsGet(
@@ -106,7 +110,8 @@ export function SystemsTable({
             page,
             pageSize,
             sortField,
-            sortDir
+            sortDir,
+            creator
           );
         setSystems(newSystems.map((sys) => newSystemModel(sys)));
         setTotal(newTotal);
@@ -124,6 +129,7 @@ export function SystemsTable({
   }, [
     nameFilter,
     taskFilter,
+    showMine,
     dataset,
     subdataset,
     split,
@@ -139,12 +145,14 @@ export function SystemsTable({
   function onFilterChange({
     name,
     task,
+    showMine,
     sortField: newSortField,
     sortDir: newSortDir,
     split: newSplit,
   }: Partial<Filter>) {
     if (name != null) setNameFilter(name);
     if (task != null) setTaskFilter(task || undefined);
+    if (showMine != null) setShowMine(showMine);
     if (newSortField != null) setSortField(newSortField);
     if (newSortDir != null) setSortDir(newSortDir);
     if (newSplit != null) setSplit(newSplit);
@@ -161,6 +169,7 @@ export function SystemsTable({
         value={{
           task: taskFilter,
           name: nameFilter,
+          showMine: showMine,
           sortField,
           sortDir,
           split,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -97,7 +97,7 @@ export function SystemsTable({
     async function refreshSystems() {
       setPageState(PageState.loading);
       const datasetSplit = split === "all" ? undefined : split;
-      const creator = showMine === true ? userEmail : "";
+      const creator = showMine === true ? userEmail : undefined;
       try {
         const { systems: newSystems, total: newTotal } =
           await backendClient.systemsGet(

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -137,6 +137,7 @@ export function SystemsTable({
     sortField,
     sortDir,
     refreshTrigger,
+    userEmail,
     loginState, // refresh when login state changes
   ]);
 

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -97,7 +97,6 @@ export function SystemsTable({
     async function refreshSystems() {
       setPageState(PageState.loading);
       const datasetSplit = split === "all" ? undefined : split;
-      // FIXME: this is hardcoded
       const creator = showMine === true ? userEmail : "";
       try {
         const { systems: newSystems, total: newTotal } =


### PR DESCRIPTION
Closes #313 
This PR adds a toggle switch in the toolbar to let users choose between "My systems" and "All systems".
"All systems" shows all the systems on Explainaboard, and "My systems" display systems which are created by the user. 
<img width="1278" alt="截圖 2022-09-12 下午8 23 03" src="https://user-images.githubusercontent.com/36850051/189781054-78ba399d-5990-4884-ad74-6f4bbbf0da5b.png">
