### PR TITLE
fix GET system outputs and cases

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -25,14 +25,12 @@ from explainaboard_web.impl.utils import (
 )
 from explainaboard_web.models import (
     AnalysisCase,
-    AnalysisCasesReturn,
     DatasetMetadata,
     System,
     SystemInfo,
     SystemMetadata,
     SystemOutput,
     SystemOutputProps,
-    SystemOutputsReturn,
     SystemsReturn,
 )
 from pymongo.client_session import ClientSession
@@ -329,12 +327,8 @@ class SystemDBUtils:
 
     @staticmethod
     def _find_output_or_case_raw(
-        system_id: str,
-        analysis_level: str,
-        output_ids: str | None,
-        page: int = 0,
-        page_size: int = 10,
-    ) -> tuple[list[dict], int]:
+        system_id: str, analysis_level: str, output_ids: str | None
+    ) -> list[dict]:
         filt: dict[str, Any] = {
             "system_id": system_id,
             "analysis_level": analysis_level,
@@ -349,10 +343,7 @@ class SystemDBUtils:
         sys_data = SystemDBUtils._decompress_from_cursor(cursor)
         if output_ids:
             sys_data = [sys_data[int(x)] for x in output_ids.split(",")]
-        total = len(sys_data)
-        if page_size:
-            sys_data = sys_data[page * page_size : (page + 1) * page_size]
-        return sys_data, total
+        return sys_data
 
     @staticmethod
     def create_system(
@@ -527,43 +518,27 @@ class SystemDBUtils:
 
     @staticmethod
     def find_system_outputs(
-        system_id: str,
-        output_ids: str | None,
-        page=0,
-        page_size=10,
-    ) -> SystemOutputsReturn:
+        system_id: str, output_ids: str | None
+    ) -> list[SystemOutput]:
         """
         find multiple system outputs whose ids are in output_ids
         """
-        sys_data, total = SystemDBUtils._find_output_or_case_raw(
-            str(system_id),
-            SystemDBUtils._SYSTEM_OUTPUT_CONST,
-            output_ids,
-            page,
-            page_size,
+        sys_data = SystemDBUtils._find_output_or_case_raw(
+            str(system_id), SystemDBUtils._SYSTEM_OUTPUT_CONST, output_ids
         )
-        return SystemOutputsReturn(
-            [SystemDBUtils.system_output_from_dict(doc) for doc in sys_data], total
-        )
+        return [SystemDBUtils.system_output_from_dict(doc) for doc in sys_data]
 
     @staticmethod
     def find_analysis_cases(
-        system_id: str,
-        level: str,
-        case_ids: str | None,
-        page: int = 0,
-        page_size: int = 10,
-    ) -> AnalysisCasesReturn:
+        system_id: str, level: str, case_ids: str | None
+    ) -> list[AnalysisCase]:
         """
         find multiple system outputs whose ids are in case_ids
-        TODO: raise error if system doesn't exist
         """
-        sys_data, total = SystemDBUtils._find_output_or_case_raw(
-            str(system_id), level, case_ids, page, page_size
+        sys_data = SystemDBUtils._find_output_or_case_raw(
+            str(system_id), level, case_ids
         )
-        return AnalysisCasesReturn(
-            [SystemDBUtils.analysis_case_from_dict(doc) for doc in sys_data], total
-        )
+        return [SystemDBUtils.analysis_case_from_dict(doc) for doc in sys_data]
 
     @staticmethod
     def delete_system_by_id(system_id: str):

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -28,7 +28,6 @@ from explainaboard_web.impl.private_dataset import is_private_dataset
 from explainaboard_web.impl.tasks import get_task_categories
 from explainaboard_web.impl.utils import abort_with_error_message, decode_base64
 from explainaboard_web.models import (
-    AnalysisCasesReturn,
     Benchmark,
     BenchmarkConfig,
     DatasetMetadata,
@@ -39,7 +38,7 @@ from explainaboard_web.models.system import System
 from explainaboard_web.models.system_analyses_return import SystemAnalysesReturn
 from explainaboard_web.models.system_create_props import SystemCreateProps
 from explainaboard_web.models.system_info import SystemInfo
-from explainaboard_web.models.system_outputs_return import SystemOutputsReturn
+from explainaboard_web.models.system_output import SystemOutput
 from explainaboard_web.models.systems_analyses_body import SystemsAnalysesBody
 from explainaboard_web.models.systems_return import SystemsReturn
 from explainaboard_web.models.task import Task
@@ -285,11 +284,8 @@ def systems_post(body: SystemCreateProps) -> System:
 
 
 def system_outputs_get_by_id(
-    system_id: str,
-    output_ids: Optional[str],
-    page: int = 0,
-    page_size: int = 10,
-) -> SystemOutputsReturn:
+    system_id: str, output_ids: Optional[str]
+) -> list[SystemOutput]:
     """
     TODO: return special error/warning if some ids cannot be found
     """
@@ -312,18 +308,14 @@ def system_outputs_get_by_id(
             403, f"{system.system_info.dataset_name} is a private dataset", 40301
         )
 
-    return SystemDBUtils.find_system_outputs(
-        system_id, output_ids, page=page, page_size=page_size
-    )
+    return SystemDBUtils.find_system_outputs(system_id, output_ids)
 
 
 def system_cases_get_by_id(
     system_id: str,
     level: int,
     case_ids: Optional[str],
-    page: int = 0,
-    page_size: int = 10,
-) -> AnalysisCasesReturn:
+) -> list[AnalysisCase]:
     """
     TODO: return special error/warning if some ids cannot be found
     """
@@ -346,10 +338,7 @@ def system_cases_get_by_id(
             403, f"{system.system_info.dataset_name} is a private dataset", 40301
         )
 
-    analysis_case_return = SystemDBUtils.find_analysis_cases(
-        system_id, level=level, case_ids=case_ids, page=page, page_size=page_size
-    )
-    return analysis_case_return
+    return SystemDBUtils.find_analysis_cases(system_id, level=level, case_ids=case_ids)
 
 
 def systems_delete_by_id(system_id: str):
@@ -439,8 +428,7 @@ def systems_analyses_post(body: SystemsAnalysesBody):
                 system_id=system.system_id,
                 level=analysis_level.name,
                 case_ids=case_ids,
-                page_size=0,
-            ).analysis_cases
+            )
             # Note we are casting here, as SystemOutput.from_dict() actually just
             # returns a dict
             level_cases = [AnalysisCase.from_dict(narrow(dict, x)) for x in level_cases]

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -336,9 +336,7 @@ function createFineGrainedBarChart(
               );
             }
           );
-          const bucketOfCasesList = (
-            await Promise.all(bucketOfCasesPromiseList)
-          ).map((x) => x.analysis_cases);
+          const bucketOfCasesList = await Promise.all(bucketOfCasesPromiseList);
           setActiveSystemExamples({
             title,
             barIndex,

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -179,7 +179,7 @@ export function AnalysisTable({ systemID, task, cases, page, setPage }: Props) {
           systemID,
           outputIDString
         );
-        setSystemOutputs(result.system_outputs);
+        setSystemOutputs(result);
       } catch (e) {
         if (e instanceof Response) {
           const error = await parseBackendError(e);

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -345,7 +345,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SystemOutputsReturn"
+                type: array
+                items:
+                  $ref: "#/components/schemas/SystemOutput"
 
   /systems/{system_id}/cases:
     get:
@@ -383,7 +385,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AnalysisCasesReturn"
+                type: array
+                items:
+                  $ref: "#/components/schemas/AnalysisCase"
 
   /systems/analyses:
     post:
@@ -995,36 +999,6 @@ components:
           example: 20
       required:
         - datasets
-        - total
-
-    SystemOutputsReturn:
-      type: object
-      properties:
-        system_outputs:
-          type: array
-          items:
-            $ref: "#/components/schemas/SystemOutput"
-        total:
-          type: integer
-          description: total number of matching system outputs
-          example: 20
-      required:
-        - system_outputs
-        - total
-
-    AnalysisCasesReturn:
-      type: object
-      properties:
-        analysis_cases:
-          type: array
-          items:
-            $ref: "#/components/schemas/AnalysisCase"
-        total:
-          type: integer
-          description: total number of matching analysis cases
-          example: 20
-      required:
-        - analysis_cases
         - total
 
     SystemsReturn:


### PR DESCRIPTION
closes #307 
- removed `page` and `page_size` from `system_outputs_get_by_id()` and `system_cases_get_by_id()` to allow the frontend to retrieve all bucket samples in one request
- removed `total` from the return values because it's not relevant anymore