### PR TITLE
rename error cases to examples

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -231,7 +231,7 @@ function createExampleTable(
   }
 
   const barText = systems.length === 1 ? "bar" : "bars";
-  const exampleText = task === "summarization" ? "Examples" : "Error cases";
+  const exampleText = "Examples";
   exampleTable = (
     <div>
       <Title level={4}>{`${exampleText} from ${barText} #${


### PR DESCRIPTION
Closes #327 
Changed "Error case" to "Examples" since the table also shows correct cases as well.
Will add "error case" in the form discussed here: https://github.com/neulab/ExplainaBoard/issues/272