### PR TITLE
use explainaboard.serialization.legacy in SDK 0.11.2

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -14,7 +14,7 @@ from bson import ObjectId
 from explainaboard import DatalabLoaderOption, FileType, Source, get_processor
 from explainaboard.loaders.file_loader import FileLoaderReturn
 from explainaboard.loaders.loader_registry import get_loader_class
-from explainaboard.utils.serialization import general_to_dict
+from explainaboard.serialization.legacy import general_to_dict
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBUtils

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -15,8 +15,8 @@ from explainaboard.analysis.case import AnalysisCase
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders import get_loader_class
 from explainaboard.metrics.metric import SimpleMetricStats
+from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
-from explainaboard.utils.serialization import general_to_dict
 from explainaboard.utils.typing_utils import narrow
 from explainaboard_web.impl.analyses.significance_analysis import (
     pairwise_significance_test,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-helmet": "^6.1.5",
         "@types/react-router-dom": "^5.3.0",
         "antd": "^4.17.0",
-        "echarts": "^5.2.2",
+        "echarts": "^5.3.3",
         "echarts-for-react": "^3.0.2",
         "eslint": "^7.32.0",
         "isomorphic-fetch": "^3.0.0",
@@ -8254,12 +8254,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.2.2.tgz",
-      "integrity": "sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.3.tgz",
+      "integrity": "sha512-BRw2serInRwO5SIwRviZ6Xgm5Lb7irgz+sLiFMmy/HOaf4SQ+7oYqxKzRHAKp4xHQ05AuHw1xvoQWJjDQq/FGw==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.2.1"
+        "zrender": "5.3.2"
       }
     },
     "node_modules/echarts-for-react": {
@@ -25041,9 +25041,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.2.1.tgz",
-      "integrity": "sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
+      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -31389,12 +31389,12 @@
       }
     },
     "echarts": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.2.2.tgz",
-      "integrity": "sha512-yxuBfeIH5c+0FsoRP60w4De6omXhA06c7eUYBsC1ykB6Ys2yK5fSteIYWvkJ4xJVLQgCvAdO8C4mN6MLeJpBaw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.3.tgz",
+      "integrity": "sha512-BRw2serInRwO5SIwRviZ6Xgm5Lb7irgz+sLiFMmy/HOaf4SQ+7oYqxKzRHAKp4xHQ05AuHw1xvoQWJjDQq/FGw==",
       "requires": {
         "tslib": "2.3.0",
-        "zrender": "5.2.1"
+        "zrender": "5.3.2"
       },
       "dependencies": {
         "tslib": {
@@ -44630,9 +44630,9 @@
       "dev": true
     },
     "zrender": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.2.1.tgz",
-      "integrity": "sha512-M3bPGZuyLTNBC6LiNKXJwSCtglMp8XUEqEBG+2MdICDI3d1s500Y4P0CzldQGsqpRVB7fkvf3BKQQRxsEaTlsw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
+      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
       "requires": {
         "tslib": "2.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "explainaboard_web",
       "version": "0.2.0",
       "license": "ISC",
-      "dependencies": {
-        "echarts": "^5.3.3",
-        "react-ga4": "^1.4.1"
-      },
       "devDependencies": {
         "concurrently": "^6.3.0",
         "husky": "^7.0.4"
@@ -133,20 +129,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/echarts": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.3.tgz",
-      "integrity": "sha512-BRw2serInRwO5SIwRviZ6Xgm5Lb7irgz+sLiFMmy/HOaf4SQ+7oYqxKzRHAKp4xHQ05AuHw1xvoQWJjDQq/FGw==",
-      "dependencies": {
-        "tslib": "2.3.0",
-        "zrender": "5.3.2"
-      }
-    },
-    "node_modules/echarts/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -209,11 +191,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/react-ga4": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
-      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -350,19 +327,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/zrender": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
-      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
-      "dependencies": {
-        "tslib": "2.3.0"
-      }
-    },
-    "node_modules/zrender/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     }
   },
   "dependencies": {
@@ -450,22 +414,6 @@
       "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==",
       "dev": true
     },
-    "echarts": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.3.3.tgz",
-      "integrity": "sha512-BRw2serInRwO5SIwRviZ6Xgm5Lb7irgz+sLiFMmy/HOaf4SQ+7oYqxKzRHAKp4xHQ05AuHw1xvoQWJjDQq/FGw==",
-      "requires": {
-        "tslib": "2.3.0",
-        "zrender": "5.3.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-        }
-      }
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -507,11 +455,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "react-ga4": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
-      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -612,21 +555,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
-    },
-    "zrender": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.3.2.tgz",
-      "integrity": "sha512-8IiYdfwHj2rx0UeIGZGGU4WEVSDEdeVCaIg/fomejg1Xu6OifAL1GVzIPHg2D+MyUkbNgPWji90t0a8IDk+39w==",
-      "requires": {
-        "tslib": "2.3.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
After updating SDK to version 0.11.2, the web cannot run locally due to import error 
```
[0]   File "/Users/jiangqi/Desktop/Capstone/explainaboard_web/backend/src/gen/explainaboard_web/impl/db_utils/system_db_utils.py", line 17, in <module>
[0]     from explainaboard.utils.serialization import general_to_dict
[0] ModuleNotFoundError: No module named 'explainaboard.utils.serialization'
[0] npm run start-backend exited with code 1
```

In the new SDK, the `general_to_dict` function is in `explainaboard.serialization.legacy`. 
Fix import error by using `from explainaboard.serialization.legacy import general_to_dict`
