### PR TITLE
feat: bind all filters with the url

### DIFF
--- a/frontend/src/components/SystemsTable/SystemFilter.ts
+++ b/frontend/src/components/SystemsTable/SystemFilter.ts
@@ -25,7 +25,7 @@ export class SystemFilter {
   subdataset: string;
   activeSystemIDs: Array<string>;
 
-  constructor(partial: Partial<FilterUpdate> | null) {
+  constructor(partial: FilterUpdate | null) {
     if (!partial) {
       this.name = "";
       this.task = "";

--- a/frontend/src/components/SystemsTable/SystemFilter.tsx
+++ b/frontend/src/components/SystemsTable/SystemFilter.tsx
@@ -1,0 +1,181 @@
+const filterDelim = "..";
+export const filterKeyMap = {
+  nameFilter: "name",
+  taskFilter: "task",
+  showMine: "show_mine",
+  sortField: "sort_field",
+  sortDir: "sort_dir",
+  dataset: "dataset",
+  datasetSplit: "dataset_split",
+  subdataset: "sub_dataset",
+  activeSystemIDs: "system_id",
+};
+
+export type FilterUpdate = Partial<SystemFilter>;
+export type QueryDict = { [key: string]: string };
+
+export class SystemFilter {
+  name: string;
+  task: string;
+  showMine: boolean;
+  sortField: string;
+  sortDir: "asc" | "desc";
+  dataset: string;
+  split: string;
+  subdataset: string;
+  activeSystemIDs: Array<string>;
+
+  constructor(partial: Partial<FilterUpdate> | null) {
+    if (!partial) {
+      this.name = "";
+      this.task = "";
+      this.showMine = false;
+      this.sortField = "created_at";
+      this.sortDir = "desc";
+      this.dataset = "";
+      this.split = "";
+      this.subdataset = "";
+      this.activeSystemIDs = [];
+      return;
+    }
+
+    const defaultFilter = SystemFilter.getDefaultFilter();
+    this.name = partial.name || defaultFilter.name;
+    this.task = partial.task || defaultFilter.task;
+    this.showMine =
+      partial.showMine === undefined
+        ? defaultFilter.showMine
+        : partial.showMine;
+    this.sortField = partial.sortField || defaultFilter.sortField;
+    this.sortDir = partial.sortDir || defaultFilter.sortDir;
+    this.dataset = partial.dataset || defaultFilter.dataset;
+    this.split = partial.split || defaultFilter.split;
+    this.subdataset = partial.subdataset || defaultFilter.subdataset;
+    this.activeSystemIDs =
+      partial.activeSystemIDs || defaultFilter.activeSystemIDs;
+  }
+
+  /*  Update the filter with the values in the new partial filter 
+      Returns true if >= 1 of current filter values get updated
+
+      TODO: Rolling out all if statement seems necessary because Typescript
+      won't allow variable field access for classes. Is there a bette way tho?
+  */
+  update(partial: FilterUpdate): boolean {
+    let updated = false;
+
+    if (partial.name && this.name !== partial.name) {
+      updated = true;
+      this.name = partial.name;
+    }
+
+    if ((partial.task && this.task !== partial.task) || partial.task === "") {
+      updated = true;
+      this.task = partial.task;
+    }
+
+    if (partial.showMine !== undefined && this.showMine !== partial.showMine) {
+      updated = true;
+      this.showMine = partial.showMine;
+    }
+
+    if (partial.sortField && this.sortField !== partial.sortField) {
+      updated = true;
+      this.sortField = partial.sortField;
+    }
+
+    if (partial.sortDir && this.sortDir !== partial.sortDir) {
+      updated = true;
+      this.sortDir = partial.sortDir;
+    }
+
+    if (partial.dataset && this.dataset !== partial.dataset) {
+      updated = true;
+      this.dataset = partial.dataset;
+    }
+
+    if (partial.split && this.split !== partial.split) {
+      updated = true;
+      this.split = partial.split;
+    }
+
+    if (partial.subdataset && this.subdataset !== partial.subdataset) {
+      updated = true;
+      this.subdataset = partial.subdataset;
+    }
+
+    if (
+      partial.activeSystemIDs &&
+      JSON.stringify(this.activeSystemIDs.sort()) !==
+        JSON.stringify(partial.activeSystemIDs.sort())
+    ) {
+      updated = true;
+      this.activeSystemIDs = partial.activeSystemIDs;
+    }
+
+    return updated;
+  }
+
+  toUrlParams(): URLSearchParams {
+    const queryParams = new URLSearchParams();
+    for (const [key, val] of Object.entries(
+      SystemFilter.parseFilterToQuery(this)
+    )) {
+      queryParams.append(key, val);
+    }
+    return queryParams;
+  }
+
+  static getDefaultFilter(): SystemFilter {
+    return new SystemFilter(null);
+  }
+
+  static parseQueryToFilter(query: URLSearchParams): SystemFilter {
+    const defaultFilter = SystemFilter.getDefaultFilter();
+
+    const activeSystemIDs = query.get(filterKeyMap.activeSystemIDs);
+    let activeSystemIDArray: string[];
+    if (activeSystemIDs) {
+      activeSystemIDArray = activeSystemIDs.split(filterDelim);
+    } else {
+      activeSystemIDArray = [];
+    }
+
+    return new SystemFilter({
+      name: query.get(filterKeyMap.nameFilter) || defaultFilter.name,
+      task: query.get(filterKeyMap.taskFilter) || defaultFilter.task,
+      showMine:
+        query.get(filterKeyMap.showMine) === "true"
+          ? true
+          : defaultFilter.showMine,
+      sortDir:
+        query.get(filterKeyMap.sortDir) === "asc"
+          ? "asc"
+          : defaultFilter.sortDir,
+      sortField: query.get(filterKeyMap.sortField) || defaultFilter.sortField,
+      split: query.get(filterKeyMap.datasetSplit) || defaultFilter.split,
+      activeSystemIDs: activeSystemIDArray || defaultFilter.activeSystemIDs,
+      dataset: query.get(filterKeyMap.dataset) || defaultFilter.dataset,
+      subdataset:
+        query.get(filterKeyMap.subdataset) || defaultFilter.subdataset,
+    });
+  }
+
+  static parseFilterToQuery(filter: Partial<SystemFilter>): QueryDict {
+    const dict: QueryDict = {};
+
+    if (filter.name) dict[filterKeyMap.nameFilter] = filter.name;
+    if (filter.task) dict[filterKeyMap.taskFilter] = filter.task;
+    dict[filterKeyMap.showMine] = filter.showMine ? "true" : "false";
+    dict[filterKeyMap.sortDir] = filter.sortDir === "asc" ? "asc" : "desc";
+    dict[filterKeyMap.sortField] = filter.sortField || "created_at";
+    if (filter.split) dict[filterKeyMap.datasetSplit] = filter.split;
+    if (filter.activeSystemIDs && filter.activeSystemIDs.length > 0)
+      dict[filterKeyMap.activeSystemIDs] =
+        filter.activeSystemIDs.join(filterDelim);
+    if (filter.dataset) dict[filterKeyMap.dataset] = filter.dataset;
+    if (filter.subdataset) dict[filterKeyMap.subdataset] = filter.subdataset;
+
+    return dict;
+  }
+}

--- a/frontend/src/components/SystemsTable/SystemFilter.tsx
+++ b/frontend/src/components/SystemsTable/SystemFilter.tsx
@@ -64,7 +64,7 @@ export class SystemFilter {
   update(partial: FilterUpdate): boolean {
     let updated = false;
 
-    if (partial.name && this.name !== partial.name) {
+    if ((partial.name && this.name !== partial.name) || partial.name === "") {
       updated = true;
       this.name = partial.name;
     }

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -29,7 +29,7 @@ interface Props {
   metricNames: string[];
   selectedSystemIDs: string[];
   setSelectedSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
-  setActiveSystemIDs: (ids: string[]) => void;
+  onActiveSystemChange: (ids: string[]) => void;
 }
 
 export function SystemTableContent({
@@ -42,7 +42,7 @@ export function SystemTableContent({
   metricNames,
   selectedSystemIDs,
   setSelectedSystemIDs,
-  setActiveSystemIDs,
+  onActiveSystemChange,
 }: Props) {
   const metricColumns: ColumnsType<SystemModel> = metricNames.map((metric) => ({
     dataIndex: metric,
@@ -55,7 +55,7 @@ export function SystemTableContent({
   }));
 
   function showSystemAnalysis(systemID: string) {
-    setActiveSystemIDs([systemID]);
+    onActiveSystemChange([systemID]);
   }
 
   async function deleteSystem(systemID: string) {

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -29,7 +29,7 @@ interface Props {
   metricNames: string[];
   selectedSystemIDs: string[];
   setSelectedSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
-  setActiveSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
+  setActiveSystemIDs: (ids: string[]) => void;
 }
 
 export function SystemTableContent({

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -236,7 +236,7 @@ export function SystemTableTools({
             value: opt,
             label: opt,
           }))}
-          value={value.split}
+          value={value.split || undefined}
           placeholder="Dataset split"
           onChange={(value) => onChange({ split: value })}
           style={{ minWidth: "120px" }}
@@ -244,7 +244,7 @@ export function SystemTableTools({
         <TaskSelect
           taskCategories={taskCategories}
           allowClear
-          value={value.task}
+          value={value.task || undefined}
           onChange={(value) => onChange({ task: value || "" })}
           placeholder="All Tasks"
           style={{ minWidth: "150px" }}

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -20,25 +20,18 @@ import {
 import { SystemModel } from "../../models";
 import { LoginState, useUser } from "../useUser";
 import { backendClient, parseBackendError } from "../../clients";
-export interface Filter {
-  name?: string;
-  task?: string;
-  showMine: boolean;
-  sortField: string;
-  sortDir: "asc" | "desc";
-  split: string | undefined;
-}
+import { FilterUpdate, SystemFilter } from "./SystemFilter";
 
 interface Props {
   systems: SystemModel[];
   /** show/hide submit drawer */
   toggleSubmitDrawer: () => void;
   taskCategories: TaskCategory[];
-  value: Filter;
-  onChange: (value: Partial<Filter>) => void;
+  value: SystemFilter;
+  onChange: (value: FilterUpdate) => void;
   metricOptions: string[];
   selectedSystemIDs: string[];
-  setActiveSystemIDs: (ids: string[]) => void;
+  onActiveSystemChange: (ids: string[]) => void;
 }
 export function SystemTableTools({
   systems,
@@ -48,7 +41,7 @@ export function SystemTableTools({
   onChange,
   metricOptions,
   selectedSystemIDs,
-  setActiveSystemIDs,
+  onActiveSystemChange,
 }: Props) {
   function findSelectedSystemDatasetNames() {
     const selectedSystems = systems.filter((sys) =>
@@ -128,7 +121,7 @@ export function SystemTableTools({
   // Single analysis
   if (selectedSystemIDs.length === 1) {
     analysisButton = (
-      <Button onClick={() => setActiveSystemIDs(selectedSystemIDs)}>
+      <Button onClick={() => onActiveSystemChange(selectedSystemIDs)}>
         Analysis
       </Button>
     );
@@ -149,7 +142,7 @@ export function SystemTableTools({
     analysisButton = (
       <Button
         disabled={disabled}
-        onClick={() => setActiveSystemIDs(selectedSystemIDs)}
+        onClick={() => onActiveSystemChange(selectedSystemIDs)}
       >
         Pairwise Analysis
         {warning && <WarningOutlined />}
@@ -177,7 +170,7 @@ export function SystemTableTools({
     analysisButton = (
       <Button
         disabled={disabled}
-        onClick={() => setActiveSystemIDs(selectedSystemIDs)}
+        onClick={() => onActiveSystemChange(selectedSystemIDs)}
       >
         Multiple System Analysis
         {warning && <WarningOutlined />}

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -195,9 +195,9 @@ export function SystemTableTools({
 
   /**
    * showMine radio buttion options.
-   * There are two labels, `My systems` and `All systems`. If `My systems` 
+   * There are two labels, `My systems` and `All systems`. If `My systems`
    * is clicked, value is set to `true` for `showMine`. Otherwise, false.
-   * 
+   *
    * If the user is not logged in, `My Systems` option would be disabled.
    */
   const showMineOptions = [

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -38,7 +38,7 @@ interface Props {
   onChange: (value: Partial<Filter>) => void;
   metricOptions: string[];
   selectedSystemIDs: string[];
-  setActiveSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
+  setActiveSystemIDs: (ids: string[]) => void;
 }
 export function SystemTableTools({
   systems,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -37,16 +37,6 @@ export function SystemsTable() {
     }
   }, [history, filters, query]);
 
-  const updateFilterAndQuery = useCallback(
-    (currFilters: SystemFilter, updates: FilterUpdate) => {
-      const updated = currFilters.update(updates);
-      if (updated) {
-        setFilters(new SystemFilter(currFilters));
-      }
-    },
-    []
-  );
-
   // submit
   const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);
 
@@ -115,11 +105,22 @@ export function SystemsTable() {
         );
         updates.sortField = initialSortField;
       }
+
+      function updateFilterAndQuery(
+        currFilters: SystemFilter,
+        updates: FilterUpdate
+      ) {
+        const updated = currFilters.update(updates);
+        if (updated) {
+          setFilters(new SystemFilter(currFilters));
+        }
+      }
+
       updateFilterAndQuery(filters, updates);
       setPage(0);
       setSelectedSystemIDs([]);
     },
-    [taskCategories, filters, updateFilterAndQuery]
+    [taskCategories, filters]
   );
 
   useEffect(() => {

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./index.css";
 import { message, Space } from "antd";
 import { SystemSubmitDrawer, AnalysisDrawer } from "../../components";
@@ -83,45 +83,32 @@ export function SystemsTable() {
   }, []);
 
   /** TODO: add debounce */
-  const onFilterChange = useCallback(
-    function (updates: FilterUpdate) {
-      /* When task filter changes, also reset the ordering */
-      function getInitialSortField(
-        taskCategories: TaskCategory[],
-        taskFilter: string
-      ) {
-        if (taskFilter) {
-          const initialTask = findTask(taskCategories, taskFilter);
-          if (initialTask && initialTask.supported_metrics.length > 0)
-            return initialTask.supported_metrics[0];
-        }
-        return "created_at";
+  const onFilterChange = function (updates: FilterUpdate) {
+    /* When task filter changes, also reset the ordering */
+    function getInitialSortField(
+      taskCategories: TaskCategory[],
+      taskFilter: string
+    ) {
+      if (taskFilter) {
+        const initialTask = findTask(taskCategories, taskFilter);
+        if (initialTask && initialTask.supported_metrics.length > 0)
+          return initialTask.supported_metrics[0];
       }
+      return "created_at";
+    }
 
-      if (updates.task) {
-        const initialSortField = getInitialSortField(
-          taskCategories,
-          updates.task
-        );
-        updates.sortField = initialSortField;
-      }
+    if (updates.task) {
+      const initialSortField = getInitialSortField(
+        taskCategories,
+        updates.task
+      );
+      updates.sortField = initialSortField;
+    }
 
-      function updateFilterAndQuery(
-        currFilters: SystemFilter,
-        updates: FilterUpdate
-      ) {
-        const updated = currFilters.update(updates);
-        if (updated) {
-          setFilters(new SystemFilter(currFilters));
-        }
-      }
-
-      updateFilterAndQuery(filters, updates);
-      setPage(0);
-      setSelectedSystemIDs([]);
-    },
-    [taskCategories, filters]
-  );
+    setFilters(filters.update(updates));
+    setPage(0);
+    setSelectedSystemIDs([]);
+  };
 
   useEffect(() => {
     async function refreshSystems() {
@@ -131,11 +118,11 @@ export function SystemsTable() {
       try {
         const { systems: newSystems, total: newTotal } =
           await backendClient.systemsGet(
-            filters.name || undefined,
+            filters.name,
             filters.task,
-            filters.dataset || undefined,
-            filters.subdataset || undefined,
-            datasetSplit || undefined,
+            filters.dataset,
+            filters.subdataset,
+            datasetSplit,
             page,
             pageSize,
             filters.sortField,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -56,7 +56,7 @@ export function SystemsTable({ filters }: Props) {
   const sortDir = filters.get(filterKeyMap.sortDir) === "asc" ? "asc" : "desc";
   const sortField = filters.get(filterKeyMap.sortField) || "created_at";
   const split = filters.get(filterKeyMap.datasetSplit) || undefined;
-  const systemId = filters.get(filterKeyMap.systemId) || undefined;
+  const activeSystemIDs = filters.get(filterKeyMap.systemId) || undefined;
   const dataset = filters.get(filterKeyMap.dataset) || undefined;
   const subdataset = filters.get(filterKeyMap.subdataset) || undefined;
 
@@ -70,8 +70,12 @@ export function SystemsTable({ filters }: Props) {
   // systems selected in the table
   const [selectedSystemIDs, setSelectedSystemIDs] = useState<string[]>([]);
 
-  // systems to be analyzed
-  const [activeSystemIDs, setActiveSystemIDs] = useState<string[]>([]);
+  // set systems to be analyzed
+  const activeSystemIDArray = activeSystemIDs ? activeSystemIDs.split(",") : [];
+  const setActiveSystemIDs = (ids: string[]) => {
+    _setFilter(filters, filterKeyMap.systemId, ids.join(","));
+    history.push({ search: filters.toString() });
+  };
 
   const { state: loginState, userInfo } = useUser();
   const userEmail = userInfo?.email;
@@ -152,12 +156,6 @@ export function SystemsTable({ filters }: Props) {
     },
     [history, filters, handleTaskChange]
   );
-
-  useEffect(() => {
-    if (systemId) {
-      setActiveSystemIDs(systemId.split(","));
-    }
-  }, [systemId]);
 
   useEffect(() => {
     async function refreshSystems() {
@@ -244,7 +242,7 @@ export function SystemsTable({ filters }: Props) {
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>
-          activeSystemIDs.includes(sys.system_id)
+          activeSystemIDArray.includes(sys.system_id)
         )}
         closeDrawer={() => setActiveSystemIDs([])}
       />

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -17,6 +17,7 @@ interface Props {
   dataset?: string;
   subdataset?: string;
   datasetSplit?: string;
+  systemId?: string;
 }
 
 /** A table that lists all systems */
@@ -26,6 +27,7 @@ export function SystemsTable({
   dataset,
   subdataset,
   datasetSplit,
+  systemId,
 }: Props) {
   const [pageState, setPageState] = useState(PageState.loading);
   const [page, setPage] = useState(0);
@@ -92,6 +94,12 @@ export function SystemsTable({
     }
     fetchTasks();
   }, [initialTaskFilter]);
+
+  useEffect(() => {
+    if (systemId) {
+      setActiveSystemIDs([systemId]);
+    }
+  }, [systemId]);
 
   useEffect(() => {
     async function refreshSystems() {

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -27,6 +27,8 @@ export function SystemsTable() {
     SystemFilter.parseQueryToFilter(query)
   );
 
+  const [activeSystemIDs, setActiveSystemIds] = useState<string[]>([]);
+
   useEffect(() => {
     const prevString = query.toString();
     const newString = filters.toUrlParams().toString();
@@ -57,7 +59,7 @@ export function SystemsTable() {
 
   // set systems to be analyzed
   const onActiveSystemChange = (ids: string[]) => {
-    updateFilterAndQuery(filters, { activeSystemIDs: ids });
+    setActiveSystemIds(ids);
   };
 
   const { state: loginState, userInfo } = useUser();
@@ -191,7 +193,7 @@ export function SystemsTable() {
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>
-          filters.activeSystemIDs.includes(sys.system_id)
+          activeSystemIDs.includes(sys.system_id)
         )}
         closeDrawer={() => onActiveSystemChange([])}
       />

--- a/frontend/src/components/useQuery.tsx
+++ b/frontend/src/components/useQuery.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+export default function useQuery() {
+  const { search } = useLocation();
+  return React.useMemo(() => new URLSearchParams(search), [search]);
+}

--- a/frontend/src/pages/BenchmarkPage/index.tsx
+++ b/frontend/src/pages/BenchmarkPage/index.tsx
@@ -1,16 +1,12 @@
 import React, { useEffect, useState } from "react";
 import "./index.css";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { BenchmarkTable } from "../../components";
 import { BenchmarkCards } from "../../components/BenchmarkCards";
 import { backendClient } from "../../clients";
 import { BenchmarkConfig } from "../../clients/openapi";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
-
-function useQuery() {
-  const { search } = useLocation();
-  return React.useMemo(() => new URLSearchParams(search), [search]);
-}
+import useQuery from "../../components/useQuery";
 
 export function BenchmarkPage() {
   useGoogleAnalytics();

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -1,16 +1,12 @@
 import React from "react";
 import "./index.css";
 import { PageHeader } from "antd";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import { LeaderboardHome } from "../LeaderboardHome";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 import { Helmet } from "react-helmet";
-
-function useQuery() {
-  const { search } = useLocation();
-  return React.useMemo(() => new URLSearchParams(search), [search]);
-}
+import useQuery from "../../components/useQuery";
 
 /**
  * TODO:
@@ -51,7 +47,7 @@ export function LeaderboardPage() {
           subTitle={`Leaderboard for ${subTitle}`}
         />
         <div style={{ padding: "0 10px" }}>
-          <SystemsTable filters={query} />
+          <SystemsTable />
         </div>
       </div>
     );

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -23,7 +23,6 @@ export function LeaderboardPage() {
   const task = query.get("task") || undefined;
   const dataset = query.get("dataset") || undefined;
   const subdataset = query.get("subdataset") || undefined;
-  const split = query.get("split") || undefined;
 
   if (task || dataset || subdataset) {
     let title = "";
@@ -52,12 +51,7 @@ export function LeaderboardPage() {
           subTitle={`Leaderboard for ${subTitle}`}
         />
         <div style={{ padding: "0 10px" }}>
-          <SystemsTable
-            initialTaskFilter={task}
-            dataset={dataset}
-            subdataset={subdataset}
-            datasetSplit={split}
-          />
+          <SystemsTable filters={query} />
         </div>
       </div>
     );

--- a/frontend/src/pages/SystemsPage/index.tsx
+++ b/frontend/src/pages/SystemsPage/index.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import { PageHeader } from "antd";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import "./index.css";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 import { Helmet } from "react-helmet";
-
-function useQuery() {
-  const { search } = useLocation();
-  return React.useMemo(() => new URLSearchParams(search), [search]);
-}
 
 /**
  * Systems Page
@@ -17,7 +12,6 @@ function useQuery() {
 export function SystemsPage() {
   useGoogleAnalytics();
   const history = useHistory();
-  const query = useQuery();
 
   return (
     <div className="page">
@@ -30,7 +24,7 @@ export function SystemsPage() {
         subTitle="All systems submitted by users"
         className="header"
       />
-      <SystemsTable filters={query} />
+      <SystemsTable />
     </div>
   );
 }

--- a/frontend/src/pages/SystemsPage/index.tsx
+++ b/frontend/src/pages/SystemsPage/index.tsx
@@ -18,38 +18,19 @@ export function SystemsPage() {
   useGoogleAnalytics();
   const history = useHistory();
   const query = useQuery();
-  const system = query.get("system") || undefined;
-  const system_id = query.get("system_id") || undefined;
 
-  if (system) {
-    return (
-      <div className="page">
-        <Helmet>
-          <title>ExplainaBoard - Systems</title>
-        </Helmet>
-        <PageHeader
-          onBack={() => history.goBack()}
-          title="Systems"
-          subTitle="All systems submitted by users"
-          className="header"
-        />
-        <SystemsTable name={system} systemId={system_id} />
-      </div>
-    );
-  } else {
-    return (
-      <div className="page">
-        <Helmet>
-          <title>ExplainaBoard - Systems</title>
-        </Helmet>
-        <PageHeader
-          onBack={() => history.goBack()}
-          title="Systems"
-          subTitle="All systems submitted by users"
-          className="header"
-        />
-        <SystemsTable systemId={system_id} />
-      </div>
-    );
-  }
+  return (
+    <div className="page">
+      <Helmet>
+        <title>ExplainaBoard - Systems</title>
+      </Helmet>
+      <PageHeader
+        onBack={() => history.goBack()}
+        title="Systems"
+        subTitle="All systems submitted by users"
+        className="header"
+      />
+      <SystemsTable filters={query} />
+    </div>
+  );
 }

--- a/frontend/src/pages/SystemsPage/index.tsx
+++ b/frontend/src/pages/SystemsPage/index.tsx
@@ -19,6 +19,7 @@ export function SystemsPage() {
   const history = useHistory();
   const query = useQuery();
   const system = query.get("system") || undefined;
+  const system_id = query.get("system_id") || undefined;
 
   if (system) {
     return (
@@ -32,7 +33,7 @@ export function SystemsPage() {
           subTitle="All systems submitted by users"
           className="header"
         />
-        <SystemsTable name={system} />
+        <SystemsTable name={system} systemId={system_id} />
       </div>
     );
   } else {
@@ -47,7 +48,7 @@ export function SystemsPage() {
           subTitle="All systems submitted by users"
           className="header"
         />
-        <SystemsTable />
+        <SystemsTable systemId={system_id} />
       </div>
     );
   }


### PR DESCRIPTION
This addresses issue #326.
 
Now you can view a system analysis using `https://hostname:port/systems?system_id=<...>`.
