### PR TITLE
bump openapi version to fix Python API Client Release error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 ## Important notes on local development
 - As mentioned in quick start step 2, whenever the open API definition (openapi.yaml) changes, you must run `npm run gen-api-code` to regenerate code for the api layer.
 - The frontend and backend dependencies must be reinstalled whenever the associated dependency files are changed, including `package.json`, `frontend/package.json`, `backend/src/gen/requirements.txt` (generated from `backend/templates/requirements.mustache`).
+- ExplainaBoard API client release depends on the API defined in `openapi.yaml`. If `openapi.yaml` is changed, remember to bump up the openapi version `0.2.x` as well. 
 
 ## Deployment
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.3"
+  version: "0.2.4"
   contact:
     email: "explainaboard@gmail.com"
   license:


### PR DESCRIPTION
* Change openapi version to fix the Python API Client Release error in [action failure #319](https://github.com/neulab/explainaboard_web/actions/runs/3078584267)
* Add a reminder in README