### PR TITLE
restrict the use of AnalysisReport.setPage

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -77,7 +77,7 @@ function createOverallBarChart(
   setActiveSystemExamples: React.Dispatch<
     React.SetStateAction<ActiveSystemExamples | undefined>
   >,
-  setPage: React.Dispatch<React.SetStateAction<number>>
+  resetPage: () => void
 ) {
   const { systems, metricToSystemAnalysesParsed } = props;
   // TODO(gneubig): make this setting global somewhere
@@ -124,8 +124,7 @@ function createOverallBarChart(
         onBarClick={(barIndex: number, _: number) => {
           // Get examples of a certain bucket from all systems
           setActiveMetric(metricNames[barIndex]);
-          // reset page number
-          setPage(0);
+          resetPage();
         }}
       />
     </Col>
@@ -196,7 +195,7 @@ function createExampleTable(
         task={task}
         cases={sortedBucketOfCasesList[0]}
         page={page}
-        setPage={setPage}
+        onPageChange={setPage}
       />
     );
     // multi-system analysis
@@ -220,7 +219,7 @@ function createExampleTable(
                   task={task}
                   cases={sortedBucketOfCasesList[sysIndex]}
                   page={page}
-                  setPage={setPage}
+                  onPageChange={setPage}
                 />
               </TabPane>
             );
@@ -252,7 +251,7 @@ function createFineGrainedBarChart(
   setActiveSystemExamples: React.Dispatch<
     React.SetStateAction<ActiveSystemExamples | undefined>
   >,
-  setPage: React.Dispatch<React.SetStateAction<number>>
+  resetPage: () => void
 ) {
   const { systems, featureNameToBucketInfo, updateFeatureNameToBucketInfo } =
     props;
@@ -342,8 +341,7 @@ function createFineGrainedBarChart(
             systemIndex,
             bucketOfCasesList,
           });
-          // reset page number
-          setPage(0);
+          resetPage();
         }}
       />
       {bucketSlider}
@@ -359,7 +357,7 @@ function createMetricPane(
   setActiveSystemExamples: React.Dispatch<
     React.SetStateAction<ActiveSystemExamples | undefined>
   >,
-  setPage: React.Dispatch<React.SetStateAction<number>>
+  resetPage: () => void
 ) {
   const systemAnalysesParsed = props.metricToSystemAnalysesParsed[metric];
 
@@ -380,7 +378,7 @@ function createMetricPane(
               systemAnalysesParsed[feature],
               colSpan,
               setActiveSystemExamples,
-              setPage
+              resetPage
             )
           )
         }
@@ -396,8 +394,14 @@ export function AnalysisReport(props: Props) {
   const [activeMetric, setActiveMetric] = useState<string>(metricNames[0]);
   const [activeSystemExamples, setActiveSystemExamples] =
     useState<ActiveSystemExamples>();
-  // page number of the analysis table
+
+  // page number of the analysis table, 0 indexed
   const [page, setPage] = useState(0);
+
+  /** sets page of AnalysisTable to the first page */
+  function resetPage() {
+    setPage(0);
+  }
 
   // Create the example table if a bar is selected, empty element if not
   const exampleTable = createExampleTable(
@@ -415,7 +419,7 @@ export function AnalysisReport(props: Props) {
     colSpan,
     setActiveMetric,
     setActiveSystemExamples,
-    setPage
+    resetPage
   );
   const significanceInfo = getSignificanceTestScore(props);
   return (
@@ -445,7 +449,7 @@ export function AnalysisReport(props: Props) {
             colSpan,
             exampleTable,
             setActiveSystemExamples,
-            setPage
+            resetPage
           );
         })}
       </Tabs>

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -10,7 +10,8 @@ interface Props {
   task: string;
   cases: AnalysisCase[];
   page: number;
-  setPage: React.Dispatch<React.SetStateAction<number>>;
+  /** newPage is 0 indexed */
+  onPageChange: (newPage: number) => void;
 }
 
 function renderColInfo(
@@ -156,7 +157,13 @@ function specifyDataSeqLab(
   return dataSource;
 }
 
-export function AnalysisTable({ systemID, task, cases, page, setPage }: Props) {
+export function AnalysisTable({
+  systemID,
+  task,
+  cases,
+  page,
+  onPageChange,
+}: Props) {
   const [pageState, setPageState] = useState(PageState.loading);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
   const pageSize = 10;
@@ -267,9 +274,7 @@ export function AnalysisTable({ systemID, task, cases, page, setPage }: Props) {
         pageSize,
         // conversion between 0-based and 1-based index
         current: page + 1,
-        onChange: (newPage, newPageSize) => {
-          setPage(newPage - 1);
-        },
+        onChange: (newPage) => onPageChange(newPage - 1),
       }}
       scroll={{ y: 550, x: "max-content", scrollToFirstRowOnChange: true }}
     />

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -195,9 +195,9 @@ export function SystemTableTools({
 
   /**
    * showMine radio buttion options.
-   * There are two labels, `My systems` and `All systems`. If `My systems` 
+   * There are two labels, `My systems` and `All systems`. If `My systems`
    * is clicked, value is set to `true` for `showMine`. Otherwise, false.
-   * 
+   *
    * If the user is not logged in, `My Systems` option would be disabled.
    */
   const showMineOptions = [


### PR DESCRIPTION
part of #333 

Passing `setState` to subcomponents makes it difficult to trace which component actually changes the state and when. It's also not clear how a `React.Dispatch<React.SetStateAction<...>>` type should be invoked in the subcomponent. I refactored several instances where `setPage` is passed to subcomponents. 
- Most of the subcomponents only needed the ability to `resetPage`. 
- `AnalysisTable` actually needs to be able to trigger a page change. The property is renamed to `onPageChange` to follow the naming convention of event handlers (`on{event_name}`).