### PR TITLE
feat: editable system metadata

### DIFF
--- a/backend/src/impl/db_utils/db_utils.py
+++ b/backend/src/impl/db_utils/db_utils.py
@@ -7,7 +7,7 @@ from explainaboard_web.impl.db import get_db
 from explainaboard_web.impl.utils import abort_with_error_message
 from pymongo.client_session import ClientSession
 from pymongo.cursor import Cursor
-from pymongo.results import DeleteResult, InsertManyResult
+from pymongo.results import DeleteResult, InsertManyResult, UpdateResult
 
 
 @dataclass
@@ -101,6 +101,27 @@ class DBUtils:
             )
         except InvalidId:
             abort_with_error_message(400, f"id: {docid} is not a valid ID")
+
+    @staticmethod
+    def update_one_by_id(
+        collection: DBCollection, docid: str, field_to_value: dict
+    ) -> bool:
+        """
+        Update a document with the _id field
+        Parameters:
+          - id: value of _id
+          - field_to_value: the new "field to value"(s) to be set in the document
+        Returns: `True` if a single document has been updated
+        """
+        try:
+            result: UpdateResult = DBUtils.get_collection(collection).update_one(
+                {"_id": ObjectId(docid)}, {"$set": field_to_value}
+            )
+            if int(result.modified_count) == 1:
+                return True
+        except InvalidId:
+            abort_with_error_message(400, f"id: {docid} is not a valid ID")
+        return False
 
     @staticmethod
     def replace_one_by_id(collection: DBCollection, doc: dict):

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -432,17 +432,16 @@ class SystemDBUtils:
                     system.dataset.dataset_id if system.dataset else None
                 )
                 document.pop("dataset")
-                system_db_id = DBUtils.insert_one(DBUtils.DEV_SYSTEM_METADATA, document)
-                if not system_db_id:
-                    abort_with_error_message(400, f"failed to insert {system_id}")
-                str_db_id = str(system_db_id)
+                system_id = DBUtils.insert_one(
+                    DBUtils.DEV_SYSTEM_METADATA, document, session=session
+                )
                 # Compress the system output
                 insert_list = []
                 sample_list = [general_to_dict(v) for v in system_output_data.samples]
                 sample_compressed = SystemDBUtils._compress_data(sample_list)
                 insert_list.append(
                     {
-                        "system_id": str_db_id,
+                        "system_id": system_id,
                         "analysis_level": SystemDBUtils._SYSTEM_OUTPUT_CONST,
                         "data": sample_compressed,
                     }
@@ -458,13 +457,13 @@ class SystemDBUtils:
                     case_compressed = SystemDBUtils._compress_data(case_list)
                     insert_list.append(
                         {
-                            "system_id": str_db_id,
+                            "system_id": system_id,
                             "analysis_level": analysis_level.name,
                             "data": case_compressed,
                         }
                     )
                 # Insert system output and analysis cases
-                output_collection = DBUtils.get_system_output_collection(str_db_id)
+                output_collection = DBUtils.get_system_output_collection(system_id)
                 result = DBUtils.insert_many(
                     output_collection, insert_list, False, session
                 )
@@ -472,7 +471,7 @@ class SystemDBUtils:
                     abort_with_error_message(
                         400, f"failed to insert outputs for {system_id}"
                     )
-                return system_db_id
+                return system_id
 
             # -- perform upload to the DB
             system_id = DBUtils.execute_transaction(db_operations)

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -33,13 +33,14 @@ from explainaboard_web.models import (
     BenchmarkConfig,
     DatasetMetadata,
     SingleAnalysis,
+    SystemOutput,
 )
 from explainaboard_web.models.datasets_return import DatasetsReturn
 from explainaboard_web.models.system import System
 from explainaboard_web.models.system_analyses_return import SystemAnalysesReturn
 from explainaboard_web.models.system_create_props import SystemCreateProps
 from explainaboard_web.models.system_info import SystemInfo
-from explainaboard_web.models.system_output import SystemOutput
+from explainaboard_web.models.system_update_props import SystemUpdateProps
 from explainaboard_web.models.systems_analyses_body import SystemsAnalysesBody
 from explainaboard_web.models.systems_return import SystemsReturn
 from explainaboard_web.models.task import Task
@@ -309,6 +310,19 @@ def systems_post(body: SystemCreateProps) -> System:
         abort_with_error_message(
             400, f"file should be sent in plain text base64. ({e})"
         )
+
+
+def systems_patch_by_id(body: SystemUpdateProps, system_id: str):
+    system = SystemDBUtils.find_system_by_id(system_id)
+    user = get_user()
+    has_access = user.is_authenticated and _is_creator(system, user)
+    if not has_access:
+        abort_with_error_message(403, "system update denied", 40303)
+
+    success = SystemDBUtils.update_system_by_id(system_id, body.metadata)
+    if success:
+        return "Success"
+    abort_with_error_message(400, f"failed to update system {system_id}")
 
 
 def system_outputs_get_by_id(

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -12,7 +12,7 @@ import {
 import { ColumnsType } from "antd/lib/table";
 import { backendClient, parseBackendError } from "../../clients";
 import { SystemModel } from "../../models";
-import { DeleteOutlined } from "@ant-design/icons";
+import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { PrivateIcon } from "..";
 import { generateLeaderboardURL } from "../../utils";
 import { getOverallMap } from "../Analysis/utils";
@@ -30,6 +30,7 @@ interface Props {
   selectedSystemIDs: string[];
   setSelectedSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
   setActiveSystemIDs: React.Dispatch<React.SetStateAction<string[]>>;
+  showEditDrawer: (systemIDToEdit: string) => void;
 }
 
 export function SystemTableContent({
@@ -43,6 +44,7 @@ export function SystemTableContent({
   selectedSystemIDs,
   setSelectedSystemIDs,
   setActiveSystemIDs,
+  showEditDrawer,
 }: Props) {
   const metricColumns: ColumnsType<SystemModel> = metricNames.map((metric) => ({
     dataIndex: metric,
@@ -169,21 +171,32 @@ export function SystemTableContent({
       dataIndex: "action",
       title: "",
       fixed: "right",
-      width: 110,
+      width: 90,
       render: (_, record) => (
-        <Space size="small">
-          <Button
-            size="small"
-            onClick={() => showSystemAnalysis(record.system_id)}
-          >
-            Analysis
-          </Button>
-          <Popconfirm
-            title="Are you sure?"
-            onConfirm={() => deleteSystem(record.system_id)}
-          >
-            <Button danger size="small" icon={<DeleteOutlined />} />
-          </Popconfirm>
+        <Space size="small" direction="vertical">
+          <Space size="small">
+            <Button
+              size="small"
+              onClick={() => showSystemAnalysis(record.system_id)}
+            >
+              Analysis
+            </Button>
+          </Space>
+          <Space size="small">
+            <Button
+              size="small"
+              icon={<EditOutlined />}
+              onClick={() => {
+                showEditDrawer(record.system_id);
+              }}
+            />
+            <Popconfirm
+              title="Are you sure?"
+              onConfirm={() => deleteSystem(record.system_id)}
+            >
+              <Button danger size="small" icon={<DeleteOutlined />} />
+            </Popconfirm>
+          </Space>
         </Space>
       ),
     },

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -32,7 +32,7 @@ export interface Filter {
 interface Props {
   systems: SystemModel[];
   /** show/hide submit drawer */
-  toggleSubmitDrawer: () => void;
+  showSubmitDrawer: () => void;
   taskCategories: TaskCategory[];
   value: Filter;
   onChange: (value: Partial<Filter>) => void;
@@ -42,7 +42,7 @@ interface Props {
 }
 export function SystemTableTools({
   systems,
-  toggleSubmitDrawer,
+  showSubmitDrawer,
   taskCategories,
   value,
   onChange,
@@ -195,9 +195,9 @@ export function SystemTableTools({
 
   /**
    * showMine radio buttion options.
-   * There are two labels, `My systems` and `All systems`. If `My systems` 
+   * There are two labels, `My systems` and `All systems`. If `My systems`
    * is clicked, value is set to `true` for `showMine`. Otherwise, false.
-   * 
+   *
    * If the user is not logged in, `My Systems` option would be disabled.
    */
   const showMineOptions = [
@@ -288,7 +288,7 @@ export function SystemTableTools({
           onChange={(e) => onChange({ name: e.target.value })}
         />
 
-        <NewSystemButton onClick={toggleSubmitDrawer} />
+        <NewSystemButton onClick={showSubmitDrawer} />
       </Space>
     </div>
   );

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -55,6 +55,9 @@ export function SystemsTable({
   // systems to be analyzed
   const [activeSystemIDs, setActiveSystemIDs] = useState<string[]>([]);
 
+  // system to be edited
+  const [systemIDToEdit, setSystemIDToEdit] = useState<string>("");
+
   const { state: loginState, userInfo } = useUser();
   const userEmail = userInfo?.email;
 
@@ -160,11 +163,20 @@ export function SystemsTable({
     setSelectedSystemIDs([]);
   }
 
+  function showSubmitDrawer() {
+    setSubmitDrawerVisible(true);
+  }
+
+  function showEditDrawer(systemIDToEdit: string) {
+    setSystemIDToEdit(systemIDToEdit);
+    setSubmitDrawerVisible(true);
+  }
+
   return (
     <Space direction="vertical" style={{ width: "100%" }}>
       <SystemTableTools
         systems={systems}
-        toggleSubmitDrawer={() => setSubmitDrawerVisible((visible) => !visible)}
+        showSubmitDrawer={showSubmitDrawer}
         taskCategories={taskCategories}
         value={{
           task: taskFilter,
@@ -194,6 +206,7 @@ export function SystemsTable({
         selectedSystemIDs={selectedSystemIDs}
         setSelectedSystemIDs={setSelectedSystemIDs}
         setActiveSystemIDs={setActiveSystemIDs}
+        showEditDrawer={showEditDrawer}
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>
@@ -202,8 +215,10 @@ export function SystemsTable({
         closeDrawer={() => setActiveSystemIDs([])}
       />
       <SystemSubmitDrawer
+        systemIDToEdit={systemIDToEdit}
         visible={submitDrawerVisible}
         onClose={() => {
+          setSystemIDToEdit("");
           setSubmitDrawerVisible(false);
           setRefreshTrigger((value) => !value);
         }}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -170,7 +170,13 @@ paths:
     get:
       summary: Returns system metadata info by id
       operationId: systemsGetById
-      description: Returns a system_metadata by id. id is the DB id so it is mostly used internally.
+      description: "Returns a system_metadata by id. id is the DB id so it is mostly used internally.
+      If with_user_info is set to true and the user has permssion, the returned system_metadata will 
+      contain user information such as shared users."
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+        - {}
       parameters:
         - in: path
           name: system_id
@@ -178,6 +184,11 @@ paths:
             type: string
           required: true
           example: "619f8ef56e638da17b06b38a"
+        - in: query
+          name: with_user_info
+          schema:
+            type: boolean
+          example: True
       responses:
         "200":
           description: OK

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -191,6 +191,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/APIError"
+    patch:
+      summary: Updates a system by id
+      operationId: systemsPatchById
+      description: Updates a system by id. See requestBody for supported fields.
+      parameters:
+        - in: path
+          name: system_id
+          schema:
+            type: string
+          required: true
+          example: "619f8ef56e638da17b06b38a"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SystemUpdateProps"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Success"
+      
     delete:
       summary: Deletes a system by id
       operationId: systemsDeleteById
@@ -783,6 +809,13 @@ components:
           type: object
       required: [task_metadata_id, task_name]
 
+    SystemUpdateProps:
+      type: object
+      properties:
+        metadata:
+          $ref: "#/components/schemas/SystemMetadataUpdatable"
+      required: [metadata]
+
     SystemCreateProps:
       type: object
       properties:
@@ -794,12 +827,8 @@ components:
           $ref: "#/components/schemas/SystemOutputProps"
       required: [metadata, system_output]
 
-    SystemMetadata:
-      type: object
+    SystemMetadataUpdatable:
       properties:
-        task:
-          type: string
-          example: "text_classification"
         is_private:
           type: boolean
           default: True
@@ -809,37 +838,51 @@ components:
             type: string
           description: space-separated list of emails with which system is shared
           example: ["hello@gmail.com", "world@gmail.com"]
-        dataset_metadata_id:
-          type: string
-        dataset_split:
-          type: string
-          description: required if dataset_metadata_id specified
-          example: test
         system_name:
           type: string
-        metric_names:
-          type: array
-          items:
-            type: string
-          example: [Accuracy]
-        source_language:
-          type: string
-          example: en
-        target_language:
-          type: string
-          example: en
         system_details:
           type: object
           description: a place to store arbitrary system details you want to remember
       required:
         [
-          task,
           is_private,
           system_name,
-          metric_names,
-          source_language,
-          target_language,
         ]
+
+    SystemMetadata:
+      allOf:
+        - $ref: "#/components/schemas/SystemMetadataUpdatable"
+        - type: object
+          properties:
+            task:
+              type: string
+              example: "text_classification"
+            dataset_metadata_id:
+              type: string
+            dataset_split:
+              type: string
+              description: required if dataset_metadata_id specified
+              example: test
+            metric_names:
+              type: array
+              items:
+                type: string
+              example: [Accuracy]
+            source_language:
+              type: string
+              example: en
+            target_language:
+              type: string
+              example: en
+          required:
+            [
+              task,
+              is_private,
+              system_name,
+              metric_names,
+              source_language,
+              target_language,
+            ]
 
     SystemOutputProps:
       type: object


### PR DESCRIPTION
Closes #110 

### Features
#### Backend
- **New API GET systems/{system_id}: permission check + new query string `with_user_info`.**  Get systems by id now fails if the system is private and the user is not a creator or shared user. If `with_user_info` is set to `true`, it makes sure the user is the creator, and the returned system_metadata will contain user information such as shared users. This is needed to prefill the Edit System form.
- **New API PATCH systems/{system_id}.** This method updates a system by id. The API only supports updating `system_name`, `is_private`, `shared_users`, and `system_details`, which are defined in `SystemMetadataUpdatable` in `openapi.yaml`. Supporting other fields like `metric_names` is difficult to handle as we'll need to reprocess the system. I think it's better to let users resubmit rather than work on such a complex solution.
#### Frontend 
- **Added edit icon for every system in Systems Table.** See bottom screenshot.
- **Reuse `SystemSubmitDrawer` for editing a system**. In edit mode, all uneditable fields are hidden and have no validation rules. The editable fields are prefilled with the fetched system value. Having no validation rules for uneditable fields is OK because these fields will not be PATCHed to the backend. In a future PR, I can mark the uneditable fields as disabled and prefill the values.
- **Editing `system_details` is not supported yet.** `system_details` is stored as an object-like structure in DB. To prefill the field, I'll need to convert it back to colon or JSON format. Will implement it in a future PR.
- **The system form is cleared when `SystemSubmitDrawer` is closed in edit mode, but not in new mode.** New mode means when a user creates a new system. This allows users to conveniently reuse the previously filled values in case they accidentally close the form.

## Refactoring
#### Backend
- Reusable functions `_is_creator()` and `_is_shared_user()` for permission checking
- Reusable function `_parse_system_details_in_doc()` to parse system details

Thanks @lyuyangh for the offline discussion on whether reusing `SystemSubmitDrawer` or not!

<img width="1279" alt="Screen Shot 2022-09-20 at 1 56 52 AM" src="https://user-images.githubusercontent.com/30998659/191178409-87415ee1-5880-429a-a4a5-a6140a4be415.png">

<img width="1430" alt="Screen Shot 2022-09-20 at 1 56 18 AM" src="https://user-images.githubusercontent.com/30998659/191178333-13873e92-100d-412f-ac6a-cdd7b3459d49.png">
5ec70cb-171e-435c-b5a2-2cce0cf152cf.png">

