### PR TITLE
fix systems filter and sortedby

### DIFF
--- a/backend/src/impl/db_utils/db_utils.py
+++ b/backend/src/impl/db_utils/db_utils.py
@@ -157,7 +157,6 @@ class DBUtils:
     def find(
         collection: DBCollection,
         filt: Optional[dict] = None,
-        sort: Optional[list] = None,
         skip=0,
         limit: int = 10,
         projection: Optional[dict] = None,
@@ -167,7 +166,6 @@ class DBUtils:
         TODO: error handling for find
         Parameters:
           - filter: filter parameters for find
-          - sort: a list of sort parameters e.g. [('field1', pymongo.ASCENDING)]
           - skip: offset
           - limit: limit, pass in 0 to retrieve all documents (this is consistent with
                    the pyMongo API)
@@ -181,8 +179,6 @@ class DBUtils:
         if not filt:
             filt = {}
         cursor = DBUtils.get_collection(collection).find(filt, projection)
-        if sort:
-            cursor = cursor.sort(sort)
 
         cursor = cursor.skip(skip).limit(limit)
         total = DBUtils.count(collection, filt)

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -111,7 +111,6 @@ class SystemDBUtils:
             system.metric_stats = [
                 [unbinarize_bson(y) for y in x] for x in metric_stats
             ]
-        print("system metric_stats: ", type(system))
         return system
 
     @staticmethod
@@ -175,6 +174,7 @@ class SystemDBUtils:
                 doc, include_metric_stats=include_metric_stats
             )
             systems.append(system)
+
         if sort:
 
             def sort_metric_func(x):

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -243,8 +243,6 @@ def systems_get(
         sort_direction = "desc"
     if sort_direction not in ["asc", "desc"]:
         abort_with_error_message(400, "sort_direction needs to be one of asc or desc")
-    if sort_field != "created_at":
-        sort_field = f"system_info.results.overall.{sort_field}.value"
 
     dir = ASCENDING if sort_direction == "asc" else DESCENDING
 
@@ -257,7 +255,7 @@ def systems_get(
         dataset_name=dataset,
         subdataset_name=subdataset,
         split=split,
-        sort=[(sort_field, dir)],
+        sort=[sort_field, dir],
         creator=creator,
         shared_users=shared_users,
     )

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -195,9 +195,9 @@ export function SystemTableTools({
 
   /**
    * showMine radio buttion options.
-   * There are two labels, `My systems` and `All systems`. If `My systems` 
+   * There are two labels, `My systems` and `All systems`. If `My systems`
    * is clicked, value is set to `true` for `showMine`. Otherwise, false.
-   * 
+   *
    * If the user is not logged in, `My Systems` option would be disabled.
    */
   const showMineOptions = [
@@ -260,13 +260,13 @@ export function SystemTableTools({
           <Select
             options={[
               ...metricOptions.map((opt) => ({ value: opt, label: opt })),
-              { value: "created_at", label: "Created At" },
+              { value: "created_at", label: "Sorted By" },
             ]}
             value={value.sortField}
             onChange={(value) => onChange({ sortField: value })}
             style={{ minWidth: "120px" }}
           />
-          <Tooltip title="Click to change sort direction">
+          <Tooltip title="Click to change sort direction. Sorted by creation time by default.">
             <Button
               icon={
                 value.sortDir === "asc" ? (

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -151,7 +151,13 @@ export function SystemsTable({
     split: newSplit,
   }: Partial<Filter>) {
     if (name != null) setNameFilter(name);
-    if (task != null) setTaskFilter(task || undefined);
+    if (task != null) {
+      if (task !== taskFilter) {
+        setSortField("created_at");
+        setSortDir("desc");
+      }
+      setTaskFilter(task || undefined);
+    }
     if (showMine != null) setShowMine(showMine);
     if (newSortField != null) setSortField(newSortField);
     if (newSortDir != null) setSortDir(newSortDir);


### PR DESCRIPTION
This PR aims to solve issue #320 

Changes to the backend:
The original cursor sort string `f"system_info.results.overall.{sort_field}.value"` cannot work for cursor.sort() because the structure of `system_info.results.overall` is `array[array[Performance]]` instead of a dictionary. Move the sort function to `backend/src/impl/db_utils/system_db_utils.py`.

Changes to the frontend:
* Change `Created At` to `Sorted By` for more informative labels, and add tooltip "Sorted by creation time by default".
* Reset `Sorted By` when the filter task changes because the metrics in the sorting dropdown are changed with the task.