### PR TITLE
Wrap all sections of AnalysisReport with the same AnalysisPanel component

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -190,6 +190,7 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
     // set to true so analysis is performed next time when drawer is opened
     setShouldUpdateAnalysis(true);
     closeDrawer();
+    setSystemAnalysesReturn(undefined);
     setPageState(PageState.loading);
     setFeatureNameToBucketInfo({});
     setBucketInfoUpdated(false);

--- a/frontend/src/components/Analysis/AnalysisReport/AnalysisPanel.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/AnalysisPanel.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode } from "react";
+import { Collapse, CollapsePanelProps, Tooltip, Typography } from "antd";
+interface Props extends Partial<CollapsePanelProps> {
+  title: string;
+  titleTooltip?: string;
+  children: ReactNode;
+  disabled?: boolean;
+}
+/** A panel of the AnalysisReport. This component implements the elements that
+ * are shared among all the panel.
+ * - Each Collapse only has one Panel because it's easier to control it's behavior
+ * thi way.
+ *  */
+export function AnalysisPanel({
+  title,
+  titleTooltip,
+  children,
+  disabled,
+  ...props
+}: Props) {
+  const header = (
+    <Tooltip title={titleTooltip}>
+      <Typography.Title level={4} style={{ marginBottom: 0 }}>
+        <span style={{ color: disabled ? "gray" : "black" }}>{title}</span>
+      </Typography.Title>
+    </Tooltip>
+  );
+  return (
+    <Tooltip title={titleTooltip}>
+      <Collapse defaultActiveKey={disabled ? [] : [title]}>
+        <Collapse.Panel
+          header={header}
+          key={title}
+          showArrow={false}
+          collapsible={disabled ? "disabled" : "header"}
+          {...props}
+        >
+          {children}
+        </Collapse.Panel>
+      </Collapse>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/Analysis/AnalysisReport/AnalysisPanel.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/AnalysisPanel.tsx
@@ -9,7 +9,7 @@ interface Props extends Partial<CollapsePanelProps> {
 /** A panel of the AnalysisReport. This component implements the elements that
  * are shared among all the panel.
  * - Each Collapse only has one Panel because it's easier to control it's behavior
- * thi way.
+ * this way.
  *  */
 export function AnalysisPanel({
   title,

--- a/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BarChart } from "../..";
 import { SystemModel } from "../../../models";
 import { getOverallMap, unwrapConfidence } from "../utils";
+import { AnalysisPanel } from "./AnalysisPanel";
 interface Props {
   systems: SystemModel[];
   metricNames: string[];
@@ -43,15 +44,17 @@ export function OverallMetricsBarChart({
     resultsNumbersOfSamples.push(metricNumberOfSamples);
   }
   return (
-    <BarChart
-      title="Overall Performance"
-      seriesNames={systemNames}
-      xAxisData={metricNames}
-      seriesDataList={resultsValues}
-      seriesLabelsList={resultsValues}
-      confidenceScoresList={resultsConfidenceScores}
-      numbersOfSamplesList={resultsNumbersOfSamples}
-      onBarClick={(barIndex: number) => onBarClick(metricNames[barIndex])}
-    />
+    <AnalysisPanel title="Overall Performance">
+      <BarChart
+        title="Overall Performance"
+        seriesNames={systemNames}
+        xAxisData={metricNames}
+        seriesDataList={resultsValues}
+        seriesLabelsList={resultsValues}
+        confidenceScoresList={resultsConfidenceScores}
+        numbersOfSamplesList={resultsNumbersOfSamples}
+        onBarClick={(barIndex: number) => onBarClick(metricNames[barIndex])}
+      />
+    </AnalysisPanel>
   );
 }

--- a/frontend/src/components/Analysis/AnalysisReport/SignificanceTestList.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/SignificanceTestList.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Avatar, List } from "antd";
+import { SignificanceTestInfo } from "../../../clients/openapi";
+import { AnalysisPanel } from "./AnalysisPanel";
+
+interface Props {
+  significanceTestInfo: SignificanceTestInfo[];
+}
+export function SignificanceTestList({ significanceTestInfo }: Props) {
+  const disabled = significanceTestInfo.length === 0;
+  return (
+    <AnalysisPanel
+      title="Significance Test"
+      disabled={disabled}
+      titleTooltip={
+        disabled
+          ? "Significance Test is not available for single system analysis."
+          : undefined
+      }
+    >
+      <List
+        itemLayout="horizontal"
+        dataSource={significanceTestInfo}
+        renderItem={(item) => (
+          <List.Item>
+            <List.Item.Meta
+              avatar={
+                <Avatar src="https://explainaboard.s3.amazonaws.com/logo/task.png" />
+              }
+              title={
+                <a href="https://github.com/neulab/ExplainaBoard/tree/main/explainaboard/metrics">
+                  {item.metric_name} ({item.method_description})
+                </a>
+              }
+              description={item.result_description}
+            />
+          </List.Item>
+        )}
+      />
+    </AnalysisPanel>
+  );
+}

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -6,12 +6,14 @@ import {
 } from "../types";
 import { compareBucketOfCases, unwrapConfidence } from "../utils";
 import { BarChart, AnalysisTable } from "../../../components";
-import { Row, Col, Typography, Space, Tabs, List, Avatar } from "antd";
+import { Row, Col, Typography, Space, Tabs } from "antd";
 import { SystemModel } from "../../../models";
 import { SystemAnalysesReturn } from "../../../clients/openapi/api";
 import { BucketSlider } from "../BucketSlider";
 import { backendClient } from "../../../clients";
 import { OverallMetricsBarChart } from "./OverallMetricsBarChart";
+import { SignificanceTestList } from "./SignificanceTestList";
+import { AnalysisPanel } from "./AnalysisPanel";
 
 const { Title } = Typography;
 const { TabPane } = Tabs;
@@ -54,38 +56,6 @@ function getColSpan(props: Props) {
     return 12;
   } else {
     return 8;
-  }
-}
-
-function getSignificanceTestScore(props: Props) {
-  const { significanceTestInfo } = props;
-
-  if (significanceTestInfo !== undefined && significanceTestInfo?.length > 0) {
-    return (
-      <Typography.Title level={4}>
-        <Typography.Title level={4}>Significance Test </Typography.Title>
-        <Typography.Title level={4}> </Typography.Title>
-        <List
-          itemLayout="horizontal"
-          dataSource={significanceTestInfo}
-          renderItem={(item) => (
-            <List.Item>
-              <List.Item.Meta
-                avatar={
-                  <Avatar src="https://explainaboard.s3.amazonaws.com/logo/task.png" />
-                }
-                title={
-                  <a href="https://github.com/neulab/ExplainaBoard/tree/main/explainaboard/metrics">
-                    {item.metric_name} ({item.method_description})
-                  </a>
-                }
-                description={item.result_description}
-              />
-            </List.Item>
-          )}
-        />
-      </Typography.Title>
-    );
   }
 }
 
@@ -339,8 +309,6 @@ export function AnalysisReport(props: Props) {
   );
 
   const colSpan = getColSpan(props);
-
-  const significanceInfo = getSignificanceTestScore(props);
   return (
     <div>
       <OverallMetricsBarChart
@@ -349,33 +317,37 @@ export function AnalysisReport(props: Props) {
         onBarClick={(metricName) => setActiveMetric(metricName)}
       />
 
-      {significanceInfo}
+      {props.significanceTestInfo && (
+        <SignificanceTestList
+          significanceTestInfo={props.significanceTestInfo}
+        />
+      )}
 
-      <Typography.Title level={4}>Fine-grained Performance</Typography.Title>
+      <AnalysisPanel title="Fine-grained Performance">
+        <Typography.Paragraph>
+          Click a bar to see detailed cases of the system output at the bottom
+          of the page.
+        </Typography.Paragraph>
 
-      <Typography.Paragraph>
-        Click a bar to see detailed cases of the system output at the bottom of
-        the page.
-      </Typography.Paragraph>
-
-      <Tabs
-        activeKey={activeMetric}
-        onChange={(activeKey) => {
-          setActiveMetric(activeKey);
-          setActiveSystemExamples(undefined);
-        }}
-      >
-        {metricNames.map((metric, _) => {
-          return createMetricPane(
-            props,
-            metric,
-            colSpan,
-            exampleTable,
-            setActiveSystemExamples,
-            resetPage
-          );
-        })}
-      </Tabs>
+        <Tabs
+          activeKey={activeMetric}
+          onChange={(activeKey) => {
+            setActiveMetric(activeKey);
+            setActiveSystemExamples(undefined);
+          }}
+        >
+          {metricNames.map((metric, _) => {
+            return createMetricPane(
+              props,
+              metric,
+              colSpan,
+              exampleTable,
+              setActiveSystemExamples,
+              resetPage
+            );
+          })}
+        </Tabs>
+      </AnalysisPanel>
     </div>
   );
 }


### PR DESCRIPTION
blocked by #346 
part of #333 

- `getSignificanceTestScore` 👉 `SignificanceTestList`
- implemented `AnalysisPanel` and wrapped all sections (overall performance, significance test info, and fine-grained analysis) with it. This has the following benefits:
   - Gives a standard look to all sections of the report. 
   - We don't need to write duplicate code that defines the style of the title font size, etc.
   - We can easily add anchors to them. Anchors can be used to scroll to specific sections of the page. e.g. if a user clicks on a bar, the page should automatically scroll to the examples table. I'll add this in a future PR.
- I also made some small changes to the UI  (tagging @pfliu-nlp and @neubig here to see if you are ok with it)
   - Each section of the report is now wrapped in a Collapse.
      - The border lines clearly separate each section.
         - This makes it clear that the examples table is part of the Fine-grained analysis. This wasn't very clear before.
      - The sections are open by default but the users now have the option to collapse them.
      - The significance test section is disabled if it's not available but it's always visible so our users know we have this feature. A tooltip is added to explain when that feature is available. 
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/22896307/191411206-e8a30e69-deaf-4a36-83cb-7f3318edf551.png">
<img width="316" alt="image" src="https://user-images.githubusercontent.com/22896307/191555317-a3c27bc7-29dd-4153-8790-47c712e4f282.png">

