### PR TITLE
Turn all render functions of AnalysisReport to components

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -1,0 +1,94 @@
+import { Space, Tabs, Typography } from "antd";
+import React from "react";
+import { SystemModel } from "../../../models";
+import { AnalysisTable } from "../AnalysisTable";
+import { ActiveSystemExamples } from "../types";
+import { compareBucketOfCases } from "../utils";
+interface Props {
+  task: string;
+  systems: SystemModel[];
+  activeSystemExamples: ActiveSystemExamples | undefined;
+  setActiveSystemExamples: React.Dispatch<
+    React.SetStateAction<ActiveSystemExamples | undefined>
+  >;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+export function ExampleTable({
+  task,
+  systems,
+  activeSystemExamples,
+  setActiveSystemExamples,
+  page,
+  setPage,
+}: Props) {
+  let exampleTable = <div>&nbsp;</div>;
+  if (activeSystemExamples === undefined) {
+    return exampleTable;
+  }
+
+  const { title, barIndex, systemIndex, bucketOfCasesList } =
+    activeSystemExamples;
+
+  // Sort bucket of samples for every system
+  const sortedBucketOfCasesList = bucketOfCasesList.map((bucketOfCases) => {
+    return bucketOfCases.sort(compareBucketOfCases);
+  });
+
+  // single analysis
+  if (systems.length === 1) {
+    exampleTable = (
+      <AnalysisTable
+        systemID={systems[0].system_id}
+        task={task}
+        cases={sortedBucketOfCasesList[0]}
+        page={page}
+        onPageChange={setPage}
+      />
+    );
+    // multi-system analysis
+  } else {
+    exampleTable = (
+      <Space style={{ width: "fit-content" }}>
+        <Tabs
+          activeKey={`${systemIndex}`}
+          onChange={(activeKey) =>
+            setActiveSystemExamples({
+              ...activeSystemExamples,
+              systemIndex: Number(activeKey),
+            })
+          }
+        >
+          {systems.map((system, sysIndex) => {
+            return (
+              <Tabs.TabPane
+                tab={system.system_info.system_name}
+                key={`${sysIndex}`}
+              >
+                <AnalysisTable
+                  systemID={system.system_id}
+                  task={task}
+                  cases={sortedBucketOfCasesList[sysIndex]}
+                  page={page}
+                  onPageChange={setPage}
+                />
+              </Tabs.TabPane>
+            );
+          })}
+        </Tabs>
+      </Space>
+    );
+  }
+
+  const barText = systems.length === 1 ? "bar" : "bars";
+  const exampleText = "Examples";
+  exampleTable = (
+    <div>
+      <Typography.Title level={4}>{`${exampleText} from ${barText} #${
+        barIndex + 1
+      } in ${title}`}</Typography.Title>
+      {exampleTable}
+    </div>
+  );
+  return exampleTable;
+}

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -20,7 +20,6 @@ interface Props {
   ) => void;
   metric: string;
   results: ResultFineGrainedParsed[];
-  colSpan: number;
   setActiveSystemExamples: React.Dispatch<
     React.SetStateAction<ActiveSystemExamples | undefined>
   >;
@@ -33,7 +32,6 @@ export function FineGrainedBarChart(props: Props) {
     featureNameToBucketInfo,
     updateFeatureNameToBucketInfo,
     results,
-    colSpan,
     setActiveSystemExamples,
     resetPage,
     metric,
@@ -90,6 +88,29 @@ export function FineGrainedBarChart(props: Props) {
       result.performances.map((perf) => unwrapConfidence(perf))
     );
   }
+
+  /** The visualization chart of a fine-grained result is displayed using the "Grid" layout by Ant Design.
+    Specifically, all charts are enclosed by <Col></Col>, which are then enclosed by a single <Row></Row>.
+    Ant design takes care of overflow and auto starts a new line. */
+  function getColSpan() {
+    // Get the maximum right bound length
+    const maxRightBoundsLength = Math.max(
+      ...Object.values(featureNameToBucketInfo).map(
+        (bucketInfo) => bucketInfo.bounds.length
+      )
+    );
+    if (
+      maxRightBoundsLength > 5 ||
+      (systems.length > 1 && maxRightBoundsLength > 3)
+    ) {
+      return 24;
+    } else if (maxRightBoundsLength > 3 || systems.length > 1) {
+      return 12;
+    } else {
+      return 8;
+    }
+  }
+  const colSpan = getColSpan();
 
   return (
     <Col span={colSpan} key={resultFirst.featureDescription}>

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -1,0 +1,133 @@
+import { Col } from "antd";
+import React from "react";
+import { backendClient } from "../../../../clients";
+import { SystemModel } from "../../../../models";
+import { BarChart } from "../../BarChart";
+import { BucketSlider } from "../../BucketSlider";
+import {
+  ActiveSystemExamples,
+  BucketIntervals,
+  ResultFineGrainedParsed,
+} from "../../types";
+import { unwrapConfidence } from "../../utils";
+
+interface Props {
+  systems: SystemModel[];
+  featureNameToBucketInfo: { [feature: string]: BucketIntervals };
+  updateFeatureNameToBucketInfo: (
+    featureName: string,
+    bucketInfo: BucketIntervals
+  ) => void;
+  metric: string;
+  results: ResultFineGrainedParsed[];
+  colSpan: number;
+  setActiveSystemExamples: React.Dispatch<
+    React.SetStateAction<ActiveSystemExamples | undefined>
+  >;
+  resetPage: () => void;
+}
+
+export function FineGrainedBarChart(props: Props) {
+  const {
+    systems,
+    featureNameToBucketInfo,
+    updateFeatureNameToBucketInfo,
+    results,
+    colSpan,
+    setActiveSystemExamples,
+    resetPage,
+    metric,
+  } = props;
+  // For invariant variables across all systems, we can simply take from the first result
+  const systemNames = systems.map((system) => system.system_info.system_name);
+  const resultFirst = results[0];
+  const title = `${metric} by ${resultFirst.featureDescription}`;
+  const bucketNames = resultFirst.bucketNames;
+  const featureName = resultFirst.featureName;
+  let bucketSlider = null;
+  if (featureName in featureNameToBucketInfo) {
+    const bucketInfo = featureNameToBucketInfo[featureName];
+    const bucketRightBounds = bucketInfo.bounds;
+    if (bucketRightBounds !== undefined) {
+      const bucketMin = bucketInfo.min;
+      const bucketMax = bucketInfo.max;
+      const bucketStep = bucketMax - bucketMin <= 1.0 ? 0.01 : 1;
+      bucketSlider = (
+        <BucketSlider
+          min={bucketMin}
+          max={bucketMax}
+          marks={{
+            [bucketMin]: bucketMin.toFixed(2),
+            [bucketMax]: bucketMax.toFixed(2),
+          }}
+          step={bucketStep}
+          inputValues={bucketRightBounds}
+          onChange={(bounds) => {
+            updateFeatureNameToBucketInfo(featureName, {
+              min: bucketMin,
+              max: bucketMax,
+              bounds: bounds,
+              updated: true,
+            });
+          }}
+        />
+      );
+    }
+  }
+
+  // System-dependent variables must be taken from all systems
+  const resultsValues: number[][] = [];
+  const resultsNumbersOfSamples: number[][] = [];
+  const resultsConfidenceScores: Array<[number, number]>[] = [];
+  const resultsBucketsOfSamples: Array<[string, number[]]>[] = [];
+  for (const result of results) {
+    resultsNumbersOfSamples.push(result.numbersOfSamples);
+    resultsBucketsOfSamples.push(
+      result.cases.map((myCases) => [result.levelName, myCases])
+    );
+    resultsValues.push(result.performances.map((perf) => perf.value));
+    resultsConfidenceScores.push(
+      result.performances.map((perf) => unwrapConfidence(perf))
+    );
+  }
+
+  return (
+    <Col span={colSpan} key={resultFirst.featureDescription}>
+      <BarChart
+        title={title}
+        seriesNames={systemNames}
+        xAxisData={bucketNames}
+        seriesDataList={resultsValues}
+        seriesLabelsList={resultsValues}
+        numbersOfSamplesList={resultsNumbersOfSamples}
+        confidenceScoresList={resultsConfidenceScores}
+        onBarClick={async (barIndex: number, systemIndex: number) => {
+          // Get examples of a certain bucket from all systems
+          const bucketOfSamplesList = resultsBucketsOfSamples.map(
+            (bucketsOfSamples) => {
+              return bucketsOfSamples[barIndex];
+            }
+          );
+          const bucketOfCasesPromiseList = bucketOfSamplesList.map(
+            (bucketOfSamples, i) => {
+              return backendClient.systemCasesGetById(
+                systems[i].system_id,
+                bucketOfSamples[0],
+                bucketOfSamples[1]
+              );
+            }
+          );
+          const bucketOfCasesList = await Promise.all(bucketOfCasesPromiseList);
+          setActiveSystemExamples({
+            title,
+            barIndex,
+            systemIndex,
+            bucketOfCasesList,
+          });
+          resetPage();
+        }}
+      />
+      {bucketSlider}
+    </Col>
+  );
+}

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -1,0 +1,69 @@
+import { Row } from "antd";
+import React from "react";
+import { SystemModel } from "../../../../models";
+import {
+  ActiveSystemExamples,
+  BucketIntervals,
+  ResultFineGrainedParsed,
+} from "../../types";
+import { FineGrainedBarChart } from "./FineGrainedBarChart";
+
+interface Props {
+  systems: SystemModel[];
+  featureNameToBucketInfo: { [feature: string]: BucketIntervals };
+  updateFeatureNameToBucketInfo: (
+    featureName: string,
+    bucketInfo: BucketIntervals
+  ) => void;
+  metricToSystemAnalysesParsed: {
+    [metric: string]: { [feature: string]: ResultFineGrainedParsed[] };
+  };
+  metric: string;
+  colSpan: number;
+  exampleTable: JSX.Element;
+  setActiveSystemExamples: React.Dispatch<
+    React.SetStateAction<ActiveSystemExamples | undefined>
+  >;
+  resetPage: () => void;
+}
+export function MetricPane(props: Props) {
+  const {
+    metricToSystemAnalysesParsed,
+    metric,
+    colSpan,
+    setActiveSystemExamples,
+    resetPage,
+    exampleTable,
+  } = props;
+  const systemAnalysesParsed = metricToSystemAnalysesParsed[metric];
+
+  /*Get the parsed result from the first system for mapping.
+    FeatureNames and descriptions are invariant information
+    */
+  return (
+    <div>
+      <Row>
+        {
+          // Map the resultsFineGrainedParsed of the every element in systemAnalysesParsed
+          // into columns. One column contains a single BarChart.
+          Object.keys(systemAnalysesParsed).map((feature) => (
+            <FineGrainedBarChart
+              systems={props.systems}
+              featureNameToBucketInfo={props.featureNameToBucketInfo}
+              updateFeatureNameToBucketInfo={
+                props.updateFeatureNameToBucketInfo
+              }
+              metric={metric}
+              results={systemAnalysesParsed[feature]}
+              colSpan={colSpan}
+              setActiveSystemExamples={setActiveSystemExamples}
+              resetPage={resetPage}
+              key={feature}
+            />
+          ))
+        }
+      </Row>
+      {exampleTable}
+    </div>
+  );
+}

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -19,7 +19,6 @@ interface Props {
     [metric: string]: { [feature: string]: ResultFineGrainedParsed[] };
   };
   metric: string;
-  colSpan: number;
   exampleTable: JSX.Element;
   setActiveSystemExamples: React.Dispatch<
     React.SetStateAction<ActiveSystemExamples | undefined>
@@ -30,7 +29,6 @@ export function MetricPane(props: Props) {
   const {
     metricToSystemAnalysesParsed,
     metric,
-    colSpan,
     setActiveSystemExamples,
     resetPage,
     exampleTable,
@@ -55,7 +53,6 @@ export function MetricPane(props: Props) {
               }
               metric={metric}
               results={systemAnalysesParsed[feature]}
-              colSpan={colSpan}
               setActiveSystemExamples={setActiveSystemExamples}
               resetPage={resetPage}
               key={feature}

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Tabs, Typography } from "antd";
+import { AnalysisPanel } from "../AnalysisPanel";
+import { MetricPane } from "./MetricPane";
+import { SystemModel } from "../../../../models";
+import {
+  ActiveSystemExamples,
+  BucketIntervals,
+  ResultFineGrainedParsed,
+} from "../../types";
+
+interface Props {
+  activeMetric: string;
+  onActiveMetricChange: (newMetricName: string) => void;
+  metricNames: string[];
+  systems: SystemModel[];
+  featureNameToBucketInfo: { [feature: string]: BucketIntervals };
+  updateFeatureNameToBucketInfo: (
+    featureName: string,
+    bucketInfo: BucketIntervals
+  ) => void;
+  metricToSystemAnalysesParsed: {
+    [metric: string]: { [feature: string]: ResultFineGrainedParsed[] };
+  };
+  colSpan: number;
+  exampleTable: JSX.Element;
+  setActiveSystemExamples: React.Dispatch<
+    React.SetStateAction<ActiveSystemExamples | undefined>
+  >;
+  resetPage: () => void;
+}
+
+export function FineGrainedAnalysis({
+  activeMetric,
+  onActiveMetricChange,
+  metricNames,
+  systems,
+  featureNameToBucketInfo,
+  updateFeatureNameToBucketInfo,
+  metricToSystemAnalysesParsed,
+  colSpan,
+  exampleTable,
+  setActiveSystemExamples,
+  resetPage,
+}: Props) {
+  return (
+    <AnalysisPanel title="Fine-grained Performance">
+      <Typography.Paragraph>
+        Click a bar to see detailed cases of the system output at the bottom of
+        the page.
+      </Typography.Paragraph>
+      <Tabs activeKey={activeMetric} onChange={onActiveMetricChange}>
+        {metricNames.map((metric) => (
+          <Tabs.TabPane tab={metric} key={metric}>
+            <MetricPane
+              systems={systems}
+              featureNameToBucketInfo={featureNameToBucketInfo}
+              updateFeatureNameToBucketInfo={updateFeatureNameToBucketInfo}
+              metricToSystemAnalysesParsed={metricToSystemAnalysesParsed}
+              metric={metric}
+              colSpan={colSpan}
+              exampleTable={exampleTable}
+              setActiveSystemExamples={setActiveSystemExamples}
+              resetPage={resetPage}
+            />
+          </Tabs.TabPane>
+        ))}
+      </Tabs>
+    </AnalysisPanel>
+  );
+}

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/index.tsx
@@ -22,7 +22,6 @@ interface Props {
   metricToSystemAnalysesParsed: {
     [metric: string]: { [feature: string]: ResultFineGrainedParsed[] };
   };
-  colSpan: number;
   exampleTable: JSX.Element;
   setActiveSystemExamples: React.Dispatch<
     React.SetStateAction<ActiveSystemExamples | undefined>
@@ -38,7 +37,6 @@ export function FineGrainedAnalysis({
   featureNameToBucketInfo,
   updateFeatureNameToBucketInfo,
   metricToSystemAnalysesParsed,
-  colSpan,
   exampleTable,
   setActiveSystemExamples,
   resetPage,
@@ -58,7 +56,6 @@ export function FineGrainedAnalysis({
               updateFeatureNameToBucketInfo={updateFeatureNameToBucketInfo}
               metricToSystemAnalysesParsed={metricToSystemAnalysesParsed}
               metric={metric}
-              colSpan={colSpan}
               exampleTable={exampleTable}
               setActiveSystemExamples={setActiveSystemExamples}
               resetPage={resetPage}

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -31,32 +31,6 @@ interface Props {
   ) => void;
 }
 
-function getColSpan(props: Props) {
-  /* The visualization chart of a fine-grained result is displayed using the "Grid" layout by Ant Design.
-  Specifically, all charts are enclosed by <Col></Col>, which are then enclosed by a single <Row></Row>.
-  Ant design takes care of overflow and auto starts a new line.
-  */
-  // Get the size of the column span
-  const { systems, featureNameToBucketInfo } = props;
-
-  // Get the maximum right bound length
-  const maxRightBoundsLength = Math.max(
-    ...Object.values(featureNameToBucketInfo).map(
-      (bucketInfo) => bucketInfo.bounds.length
-    )
-  );
-  if (
-    maxRightBoundsLength > 5 ||
-    (systems.length > 1 && maxRightBoundsLength > 3)
-  ) {
-    return 24;
-  } else if (maxRightBoundsLength > 3 || systems.length > 1) {
-    return 12;
-  } else {
-    return 8;
-  }
-}
-
 function createExampleTable(
   props: Props,
   activeSystemExamples: ActiveSystemExamples | undefined,
@@ -160,7 +134,6 @@ export function AnalysisReport(props: Props) {
     setPage
   );
 
-  const colSpan = getColSpan(props);
   return (
     <div>
       <OverallMetricsBarChart
@@ -180,7 +153,6 @@ export function AnalysisReport(props: Props) {
         featureNameToBucketInfo={props.featureNameToBucketInfo}
         updateFeatureNameToBucketInfo={props.updateFeatureNameToBucketInfo}
         metricToSystemAnalysesParsed={props.metricToSystemAnalysesParsed}
-        colSpan={colSpan}
         exampleTable={exampleTable}
         setActiveSystemExamples={setActiveSystemExamples}
         resetPage={resetPage}

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -6,13 +6,13 @@ import {
 } from "../types";
 import { compareBucketOfCases } from "../utils";
 import { AnalysisTable } from "../../../components";
-import { Row, Typography, Space, Tabs } from "antd";
+import { Typography, Space, Tabs } from "antd";
 import { SystemModel } from "../../../models";
 import { SystemAnalysesReturn } from "../../../clients/openapi/api";
 import { OverallMetricsBarChart } from "./OverallMetricsBarChart";
 import { SignificanceTestList } from "./SignificanceTestList";
 import { AnalysisPanel } from "./AnalysisPanel";
-import { FineGrainedBarChart } from "./FineGrainedAnalysis/FineGrainedBarChart";
+import { MetricPane } from "./FineGrainedAnalysis/MetricPane";
 
 const { Title } = Typography;
 const { TabPane } = Tabs;
@@ -137,49 +137,6 @@ function createExampleTable(
   return exampleTable;
 }
 
-function createMetricPane(
-  props: Props,
-  metric: string,
-  colSpan: number,
-  exampleTable: JSX.Element,
-  setActiveSystemExamples: React.Dispatch<
-    React.SetStateAction<ActiveSystemExamples | undefined>
-  >,
-  resetPage: () => void
-) {
-  const systemAnalysesParsed = props.metricToSystemAnalysesParsed[metric];
-
-  /*Get the parsed result from the first system for mapping.
-  FeatureNames and descriptions are invariant information
-  */
-  return (
-    <TabPane tab={metric} key={metric}>
-      <Row>
-        {
-          // Map the resultsFineGrainedParsed of the every element in systemAnalysesParsed
-          // into columns. One column contains a single BarChart.
-          Object.keys(systemAnalysesParsed).map((feature) => (
-            <FineGrainedBarChart
-              systems={props.systems}
-              featureNameToBucketInfo={props.featureNameToBucketInfo}
-              updateFeatureNameToBucketInfo={
-                props.updateFeatureNameToBucketInfo
-              }
-              metric={metric}
-              results={systemAnalysesParsed[feature]}
-              colSpan={colSpan}
-              setActiveSystemExamples={setActiveSystemExamples}
-              resetPage={resetPage}
-              key={feature}
-            />
-          ))
-        }
-      </Row>
-      {exampleTable}
-    </TabPane>
-  );
-}
-
 export function AnalysisReport(props: Props) {
   const { metricToSystemAnalysesParsed } = props;
   const metricNames = Object.keys(metricToSystemAnalysesParsed);
@@ -232,16 +189,25 @@ export function AnalysisReport(props: Props) {
             setActiveSystemExamples(undefined);
           }}
         >
-          {metricNames.map((metric, _) => {
-            return createMetricPane(
-              props,
-              metric,
-              colSpan,
-              exampleTable,
-              setActiveSystemExamples,
-              resetPage
-            );
-          })}
+          {metricNames.map((metric) => (
+            <Tabs.TabPane tab={metric} key={metric}>
+              <MetricPane
+                systems={props.systems}
+                featureNameToBucketInfo={props.featureNameToBucketInfo}
+                updateFeatureNameToBucketInfo={
+                  props.updateFeatureNameToBucketInfo
+                }
+                metricToSystemAnalysesParsed={
+                  props.metricToSystemAnalysesParsed
+                }
+                metric={metric}
+                colSpan={colSpan}
+                exampleTable={exampleTable}
+                setActiveSystemExamples={setActiveSystemExamples}
+                resetPage={resetPage}
+              />
+            </Tabs.TabPane>
+          ))}
         </Tabs>
       </AnalysisPanel>
     </div>

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -11,8 +11,7 @@ import { SystemModel } from "../../../models";
 import { SystemAnalysesReturn } from "../../../clients/openapi/api";
 import { OverallMetricsBarChart } from "./OverallMetricsBarChart";
 import { SignificanceTestList } from "./SignificanceTestList";
-import { AnalysisPanel } from "./AnalysisPanel";
-import { MetricPane } from "./FineGrainedAnalysis/MetricPane";
+import { FineGrainedAnalysis } from "./FineGrainedAnalysis";
 
 const { Title } = Typography;
 const { TabPane } = Tabs;
@@ -176,40 +175,22 @@ export function AnalysisReport(props: Props) {
         />
       )}
 
-      <AnalysisPanel title="Fine-grained Performance">
-        <Typography.Paragraph>
-          Click a bar to see detailed cases of the system output at the bottom
-          of the page.
-        </Typography.Paragraph>
-
-        <Tabs
-          activeKey={activeMetric}
-          onChange={(activeKey) => {
-            setActiveMetric(activeKey);
-            setActiveSystemExamples(undefined);
-          }}
-        >
-          {metricNames.map((metric) => (
-            <Tabs.TabPane tab={metric} key={metric}>
-              <MetricPane
-                systems={props.systems}
-                featureNameToBucketInfo={props.featureNameToBucketInfo}
-                updateFeatureNameToBucketInfo={
-                  props.updateFeatureNameToBucketInfo
-                }
-                metricToSystemAnalysesParsed={
-                  props.metricToSystemAnalysesParsed
-                }
-                metric={metric}
-                colSpan={colSpan}
-                exampleTable={exampleTable}
-                setActiveSystemExamples={setActiveSystemExamples}
-                resetPage={resetPage}
-              />
-            </Tabs.TabPane>
-          ))}
-        </Tabs>
-      </AnalysisPanel>
+      <FineGrainedAnalysis
+        systems={props.systems}
+        featureNameToBucketInfo={props.featureNameToBucketInfo}
+        updateFeatureNameToBucketInfo={props.updateFeatureNameToBucketInfo}
+        metricToSystemAnalysesParsed={props.metricToSystemAnalysesParsed}
+        colSpan={colSpan}
+        exampleTable={exampleTable}
+        setActiveSystemExamples={setActiveSystemExamples}
+        resetPage={resetPage}
+        activeMetric={activeMetric}
+        onActiveMetricChange={(newMetricName) => {
+          setActiveMetric(newMetricName);
+          setActiveSystemExamples(undefined);
+        }}
+        metricNames={metricNames}
+      />
     </div>
   );
 }

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -4,17 +4,12 @@ import {
   ResultFineGrainedParsed,
   BucketIntervals,
 } from "../types";
-import { compareBucketOfCases } from "../utils";
-import { AnalysisTable } from "../../../components";
-import { Typography, Space, Tabs } from "antd";
 import { SystemModel } from "../../../models";
 import { SystemAnalysesReturn } from "../../../clients/openapi/api";
 import { OverallMetricsBarChart } from "./OverallMetricsBarChart";
 import { SignificanceTestList } from "./SignificanceTestList";
 import { FineGrainedAnalysis } from "./FineGrainedAnalysis";
-
-const { Title } = Typography;
-const { TabPane } = Tabs;
+import { ExampleTable } from "./ExampleTable";
 
 interface Props {
   task: string;
@@ -29,85 +24,6 @@ interface Props {
     featureName: string,
     bucketInfo: BucketIntervals
   ) => void;
-}
-
-function createExampleTable(
-  props: Props,
-  activeSystemExamples: ActiveSystemExamples | undefined,
-  setActiveSystemExamples: React.Dispatch<
-    React.SetStateAction<ActiveSystemExamples | undefined>
-  >,
-  page: number,
-  setPage: React.Dispatch<React.SetStateAction<number>>
-) {
-  // Create a table full of examples
-  let exampleTable = <div>&nbsp;</div>;
-  if (activeSystemExamples === undefined) {
-    return exampleTable;
-  }
-
-  const { task, systems } = props;
-  const { title, barIndex, systemIndex, bucketOfCasesList } =
-    activeSystemExamples;
-
-  // Sort bucket of samples for every system
-  const sortedBucketOfCasesList = bucketOfCasesList.map((bucketOfCases) => {
-    return bucketOfCases.sort(compareBucketOfCases);
-  });
-
-  // single analysis
-  if (systems.length === 1) {
-    exampleTable = (
-      <AnalysisTable
-        systemID={systems[0].system_id}
-        task={task}
-        cases={sortedBucketOfCasesList[0]}
-        page={page}
-        onPageChange={setPage}
-      />
-    );
-    // multi-system analysis
-  } else {
-    exampleTable = (
-      <Space style={{ width: "fit-content" }}>
-        <Tabs
-          activeKey={`${systemIndex}`}
-          onChange={(activeKey) =>
-            setActiveSystemExamples({
-              ...activeSystemExamples,
-              systemIndex: Number(activeKey),
-            })
-          }
-        >
-          {systems.map((system, sysIndex) => {
-            return (
-              <TabPane tab={system.system_info.system_name} key={`${sysIndex}`}>
-                <AnalysisTable
-                  systemID={system.system_id}
-                  task={task}
-                  cases={sortedBucketOfCasesList[sysIndex]}
-                  page={page}
-                  onPageChange={setPage}
-                />
-              </TabPane>
-            );
-          })}
-        </Tabs>
-      </Space>
-    );
-  }
-
-  const barText = systems.length === 1 ? "bar" : "bars";
-  const exampleText = "Examples";
-  exampleTable = (
-    <div>
-      <Title level={4}>{`${exampleText} from ${barText} #${
-        barIndex + 1
-      } in ${title}`}</Title>
-      {exampleTable}
-    </div>
-  );
-  return exampleTable;
 }
 
 export function AnalysisReport(props: Props) {
@@ -125,13 +41,16 @@ export function AnalysisReport(props: Props) {
     setPage(0);
   }
 
-  // Create the example table if a bar is selected, empty element if not
-  const exampleTable = createExampleTable(
-    props,
-    activeSystemExamples,
-    setActiveSystemExamples,
-    page,
-    setPage
+  /** Create the example table if a bar is selected, empty element if not */
+  const exampleTable = (
+    <ExampleTable
+      task={props.task}
+      systems={props.systems}
+      activeSystemExamples={activeSystemExamples}
+      setActiveSystemExamples={setActiveSystemExamples}
+      page={page}
+      setPage={setPage}
+    />
   );
 
   return (


### PR DESCRIPTION
part of #333 
Made `AnalysisReport` more react-like so the hierarchy of components is more obvious. I also removed unused props for these components. 
- `createFineGrainedBarChart` -> `FineGrainedBarChart`
- `createMetricPane` -> `MetricPane`
- created `FineGrainedAnalysis`
- move `colSpan` to `FineGrainedBarChart`