### PR TITLE
make ExampleTable a subcomponent of MetricPane

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -1,14 +1,16 @@
+import React, { useState } from "react";
 import { Row } from "antd";
-import React from "react";
 import { SystemModel } from "../../../../models";
 import {
   ActiveSystemExamples,
   BucketIntervals,
   ResultFineGrainedParsed,
 } from "../../types";
+import { ExampleTable } from "../ExampleTable";
 import { FineGrainedBarChart } from "./FineGrainedBarChart";
 
 interface Props {
+  task: string;
   systems: SystemModel[];
   featureNameToBucketInfo: { [feature: string]: BucketIntervals };
   updateFeatureNameToBucketInfo: (
@@ -19,25 +21,16 @@ interface Props {
     [metric: string]: { [feature: string]: ResultFineGrainedParsed[] };
   };
   metric: string;
-  exampleTable: JSX.Element;
-  setActiveSystemExamples: React.Dispatch<
-    React.SetStateAction<ActiveSystemExamples | undefined>
-  >;
-  resetPage: () => void;
 }
 export function MetricPane(props: Props) {
-  const {
-    metricToSystemAnalysesParsed,
-    metric,
-    setActiveSystemExamples,
-    resetPage,
-    exampleTable,
-  } = props;
+  const { task, systems, metricToSystemAnalysesParsed, metric } = props;
   const systemAnalysesParsed = metricToSystemAnalysesParsed[metric];
 
-  /*Get the parsed result from the first system for mapping.
-    FeatureNames and descriptions are invariant information
-    */
+  const [activeSystemExamples, setActiveSystemExamples] =
+    useState<ActiveSystemExamples>();
+  // page number of the analysis table, 0 indexed
+  const [page, setPage] = useState(0);
+
   return (
     <div>
       <Row>
@@ -54,13 +47,20 @@ export function MetricPane(props: Props) {
               metric={metric}
               results={systemAnalysesParsed[feature]}
               setActiveSystemExamples={setActiveSystemExamples}
-              resetPage={resetPage}
+              resetPage={() => setPage(0)}
               key={feature}
             />
           ))
         }
       </Row>
-      {exampleTable}
+      <ExampleTable
+        task={task}
+        systems={systems}
+        activeSystemExamples={activeSystemExamples}
+        setActiveSystemExamples={setActiveSystemExamples}
+        page={page}
+        setPage={setPage}
+      />
     </div>
   );
 }

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/index.tsx
@@ -3,13 +3,10 @@ import { Tabs, Typography } from "antd";
 import { AnalysisPanel } from "../AnalysisPanel";
 import { MetricPane } from "./MetricPane";
 import { SystemModel } from "../../../../models";
-import {
-  ActiveSystemExamples,
-  BucketIntervals,
-  ResultFineGrainedParsed,
-} from "../../types";
+import { BucketIntervals, ResultFineGrainedParsed } from "../../types";
 
 interface Props {
+  task: string;
   activeMetric: string;
   onActiveMetricChange: (newMetricName: string) => void;
   metricNames: string[];
@@ -22,14 +19,10 @@ interface Props {
   metricToSystemAnalysesParsed: {
     [metric: string]: { [feature: string]: ResultFineGrainedParsed[] };
   };
-  exampleTable: JSX.Element;
-  setActiveSystemExamples: React.Dispatch<
-    React.SetStateAction<ActiveSystemExamples | undefined>
-  >;
-  resetPage: () => void;
 }
 
 export function FineGrainedAnalysis({
+  task,
   activeMetric,
   onActiveMetricChange,
   metricNames,
@@ -37,9 +30,6 @@ export function FineGrainedAnalysis({
   featureNameToBucketInfo,
   updateFeatureNameToBucketInfo,
   metricToSystemAnalysesParsed,
-  exampleTable,
-  setActiveSystemExamples,
-  resetPage,
 }: Props) {
   return (
     <AnalysisPanel title="Fine-grained Performance">
@@ -51,14 +41,12 @@ export function FineGrainedAnalysis({
         {metricNames.map((metric) => (
           <Tabs.TabPane tab={metric} key={metric}>
             <MetricPane
+              task={task}
               systems={systems}
               featureNameToBucketInfo={featureNameToBucketInfo}
               updateFeatureNameToBucketInfo={updateFeatureNameToBucketInfo}
               metricToSystemAnalysesParsed={metricToSystemAnalysesParsed}
               metric={metric}
-              exampleTable={exampleTable}
-              setActiveSystemExamples={setActiveSystemExamples}
-              resetPage={resetPage}
             />
           </Tabs.TabPane>
         ))}

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -1,15 +1,10 @@
 import React, { useState } from "react";
-import {
-  ActiveSystemExamples,
-  ResultFineGrainedParsed,
-  BucketIntervals,
-} from "../types";
+import { ResultFineGrainedParsed, BucketIntervals } from "../types";
 import { SystemModel } from "../../../models";
 import { SystemAnalysesReturn } from "../../../clients/openapi/api";
 import { OverallMetricsBarChart } from "./OverallMetricsBarChart";
 import { SignificanceTestList } from "./SignificanceTestList";
 import { FineGrainedAnalysis } from "./FineGrainedAnalysis";
-import { ExampleTable } from "./ExampleTable";
 
 interface Props {
   task: string;
@@ -27,59 +22,41 @@ interface Props {
 }
 
 export function AnalysisReport(props: Props) {
-  const { metricToSystemAnalysesParsed } = props;
+  const {
+    task,
+    systems,
+    metricToSystemAnalysesParsed,
+    significanceTestInfo,
+    updateFeatureNameToBucketInfo,
+    featureNameToBucketInfo,
+  } = props;
   const metricNames = Object.keys(metricToSystemAnalysesParsed);
   const [activeMetric, setActiveMetric] = useState<string>(metricNames[0]);
-  const [activeSystemExamples, setActiveSystemExamples] =
-    useState<ActiveSystemExamples>();
 
-  // page number of the analysis table, 0 indexed
-  const [page, setPage] = useState(0);
-
-  /** sets page of AnalysisTable to the first page */
-  function resetPage() {
-    setPage(0);
+  function onActiveMetricChange(newMetricName: string) {
+    setActiveMetric(newMetricName);
   }
-
-  /** Create the example table if a bar is selected, empty element if not */
-  const exampleTable = (
-    <ExampleTable
-      task={props.task}
-      systems={props.systems}
-      activeSystemExamples={activeSystemExamples}
-      setActiveSystemExamples={setActiveSystemExamples}
-      page={page}
-      setPage={setPage}
-    />
-  );
 
   return (
     <div>
       <OverallMetricsBarChart
-        systems={props.systems}
+        systems={systems}
         metricNames={Object.keys(metricToSystemAnalysesParsed)}
-        onBarClick={(metricName) => setActiveMetric(metricName)}
+        onBarClick={onActiveMetricChange}
       />
 
-      {props.significanceTestInfo && (
-        <SignificanceTestList
-          significanceTestInfo={props.significanceTestInfo}
-        />
+      {significanceTestInfo && (
+        <SignificanceTestList significanceTestInfo={significanceTestInfo} />
       )}
 
       <FineGrainedAnalysis
-        systems={props.systems}
-        featureNameToBucketInfo={props.featureNameToBucketInfo}
-        updateFeatureNameToBucketInfo={props.updateFeatureNameToBucketInfo}
-        metricToSystemAnalysesParsed={props.metricToSystemAnalysesParsed}
-        exampleTable={exampleTable}
-        setActiveSystemExamples={setActiveSystemExamples}
-        resetPage={resetPage}
+        task={task}
+        systems={systems}
+        featureNameToBucketInfo={featureNameToBucketInfo}
+        updateFeatureNameToBucketInfo={updateFeatureNameToBucketInfo}
+        metricToSystemAnalysesParsed={metricToSystemAnalysesParsed}
         activeMetric={activeMetric}
-        onActiveMetricChange={(newMetricName) => {
-          setActiveMetric(newMetricName);
-          setActiveSystemExamples(undefined);
-        }}
+        onActiveMetricChange={onActiveMetricChange}
         metricNames={metricNames}
       />
     </div>


### PR DESCRIPTION
part of #333 

Each `MetricPanel` now has its own `ExampleTable` and `activeSystemExamples` state. This makes more logical sense because the examples are associated with the bar charts. This also reduces the complexity of the code because we don't need to pass `activeSystemExamples` and `page` through several components down the hierarchy.