### PR TITLE
Refactor MetricPane

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -1,63 +1,49 @@
-import { Space, Tabs, Typography } from "antd";
 import React from "react";
+import { Result, Space, Tabs, Typography } from "antd";
 import { SystemModel } from "../../../models";
 import { AnalysisTable } from "../AnalysisTable";
-import { ActiveSystemExamples } from "../types";
-import { compareBucketOfCases } from "../utils";
+import { AnalysisCase } from "../../../clients/openapi";
+
 interface Props {
+  /** title of the table */
+  title: string;
   task: string;
   systems: SystemModel[];
-  activeSystemExamples: ActiveSystemExamples | undefined;
-  setActiveSystemExamples: React.Dispatch<
-    React.SetStateAction<ActiveSystemExamples | undefined>
-  >;
-  page: number;
-  setPage: React.Dispatch<React.SetStateAction<number>>;
+  /** sampleIDs to show for each system; numSystems x numSamples */
+  cases: AnalysisCase[][];
+  activeSystemIndex: number;
+  onActiveSystemIndexChange: (newSystemIndex: number) => void;
 }
 export function ExampleTable({
+  title,
   task,
   systems,
-  activeSystemExamples,
-  setActiveSystemExamples,
-  page,
-  setPage,
+  cases,
+  activeSystemIndex,
+  onActiveSystemIndexChange,
 }: Props) {
-  let exampleTable = <div>&nbsp;</div>;
-  if (activeSystemExamples === undefined) {
-    return exampleTable;
-  }
-
-  const { title, barIndex, systemIndex, bucketOfCasesList } =
-    activeSystemExamples;
-
-  // Sort bucket of samples for every system
-  const sortedBucketOfCasesList = bucketOfCasesList.map((bucketOfCases) => {
-    return bucketOfCases.sort(compareBucketOfCases);
-  });
-
-  // single analysis
-  if (systems.length === 1) {
+  let exampleTable: React.ReactNode;
+  if (systems.length !== cases.length) {
+    console.error(
+      `ExampleTable input error: systems=${systems}, cases=${cases} doesn't match`
+    );
+    exampleTable = <Result status="error" title="Failed to show examples." />;
+  } else if (systems.length === 1) {
+    // single analysis
     exampleTable = (
       <AnalysisTable
         systemID={systems[0].system_id}
         task={task}
-        cases={sortedBucketOfCasesList[0]}
-        page={page}
-        onPageChange={setPage}
+        cases={cases[0]}
       />
     );
-    // multi-system analysis
   } else {
+    // multi-system analysis
     exampleTable = (
       <Space style={{ width: "fit-content" }}>
         <Tabs
-          activeKey={`${systemIndex}`}
-          onChange={(activeKey) =>
-            setActiveSystemExamples({
-              ...activeSystemExamples,
-              systemIndex: Number(activeKey),
-            })
-          }
+          activeKey={`${activeSystemIndex}`}
+          onChange={(activeKey) => onActiveSystemIndexChange(Number(activeKey))}
         >
           {systems.map((system, sysIndex) => {
             return (
@@ -68,9 +54,7 @@ export function ExampleTable({
                 <AnalysisTable
                   systemID={system.system_id}
                   task={task}
-                  cases={sortedBucketOfCasesList[sysIndex]}
-                  page={page}
-                  onPageChange={setPage}
+                  cases={cases[sysIndex]}
                 />
               </Tabs.TabPane>
             );
@@ -80,15 +64,10 @@ export function ExampleTable({
     );
   }
 
-  const barText = systems.length === 1 ? "bar" : "bars";
-  const exampleText = "Examples";
-  exampleTable = (
+  return (
     <div>
-      <Typography.Title level={4}>{`${exampleText} from ${barText} #${
-        barIndex + 1
-      } in ${title}`}</Typography.Title>
+      <Typography.Title level={4}>{title}</Typography.Title>
       {exampleTable}
     </div>
   );
-  return exampleTable;
 }

--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -3,6 +3,7 @@ import { Result, Space, Tabs, Typography } from "antd";
 import { SystemModel } from "../../../models";
 import { AnalysisTable } from "../AnalysisTable";
 import { AnalysisCase } from "../../../clients/openapi";
+import { PageState } from "../../../utils";
 
 interface Props {
   /** title of the table */
@@ -13,6 +14,7 @@ interface Props {
   cases: AnalysisCase[][];
   activeSystemIndex: number;
   onActiveSystemIndexChange: (newSystemIndex: number) => void;
+  changeState: (newState: PageState) => void;
 }
 export function ExampleTable({
   title,
@@ -21,6 +23,7 @@ export function ExampleTable({
   cases,
   activeSystemIndex,
   onActiveSystemIndexChange,
+  changeState,
 }: Props) {
   let exampleTable: React.ReactNode;
   if (systems.length !== cases.length) {
@@ -35,6 +38,7 @@ export function ExampleTable({
         systemID={systems[0].system_id}
         task={task}
         cases={cases[0]}
+        changeState={changeState}
       />
     );
   } else {
@@ -55,6 +59,7 @@ export function ExampleTable({
                   systemID={system.system_id}
                   task={task}
                   cases={cases[sysIndex]}
+                  changeState={changeState}
                 />
               </Tabs.TabPane>
             );

--- a/frontend/src/components/Analysis/AnalysisReport/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { ResultFineGrainedParsed, BucketIntervals } from "../types";
 import { SystemModel } from "../../../models";
 import { SystemAnalysesReturn } from "../../../clients/openapi/api";
@@ -30,8 +30,15 @@ export function AnalysisReport(props: Props) {
     updateFeatureNameToBucketInfo,
     featureNameToBucketInfo,
   } = props;
-  const metricNames = Object.keys(metricToSystemAnalysesParsed);
+  const metricNames = useMemo(
+    () => Object.keys(metricToSystemAnalysesParsed),
+    [metricToSystemAnalysesParsed]
+  );
   const [activeMetric, setActiveMetric] = useState<string>(metricNames[0]);
+
+  useEffect(() => {
+    setActiveMetric(metricNames[0]);
+  }, [metricNames]);
 
   function onActiveMetricChange(newMetricName: string) {
     setActiveMetric(newMetricName);

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -9,9 +9,6 @@ interface Props {
   systemID: string;
   task: string;
   cases: AnalysisCase[];
-  page: number;
-  /** newPage is 0 indexed */
-  onPageChange: (newPage: number) => void;
 }
 
 function renderColInfo(
@@ -157,18 +154,17 @@ function specifyDataSeqLab(
   return dataSource;
 }
 
-export function AnalysisTable({
-  systemID,
-  task,
-  cases,
-  page,
-  onPageChange,
-}: Props) {
+export function AnalysisTable({ systemID, task, cases }: Props) {
+  const [page, setPage] = useState(0);
   const [pageState, setPageState] = useState(PageState.loading);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
   const pageSize = 10;
   const total = cases.length;
   const tableRef = useRef<null | HTMLDivElement>(null);
+
+  useEffect(() => {
+    setPage(0);
+  }, [cases]);
 
   useEffect(() => {
     async function refreshSystemOutputs() {
@@ -274,7 +270,7 @@ export function AnalysisTable({
         pageSize,
         // conversion between 0-based and 1-based index
         current: page + 1,
-        onChange: (newPage) => onPageChange(newPage - 1),
+        onChange: (newPage) => setPage(newPage - 1),
       }}
       scroll={{ y: 550, x: "max-content", scrollToFirstRowOnChange: true }}
     />

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   systemID: string;
   task: string;
   cases: AnalysisCase[];
+  changeState: (newState: PageState) => void;
 }
 
 function renderColInfo(
@@ -154,9 +155,9 @@ function specifyDataSeqLab(
   return dataSource;
 }
 
-export function AnalysisTable({ systemID, task, cases }: Props) {
+export function AnalysisTable({ systemID, task, cases, changeState }: Props) {
   const [page, setPage] = useState(0);
-  const [pageState, setPageState] = useState(PageState.loading);
+
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
   const pageSize = 10;
   const total = cases.length;
@@ -168,7 +169,7 @@ export function AnalysisTable({ systemID, task, cases }: Props) {
 
   useEffect(() => {
     async function refreshSystemOutputs() {
-      setPageState(PageState.loading);
+      changeState(PageState.loading);
       try {
         const offset = page * pageSize;
         const end = Math.min(offset + pageSize, cases.length);
@@ -188,7 +189,7 @@ export function AnalysisTable({ systemID, task, cases }: Props) {
           }
         }
       } finally {
-        setPageState(PageState.success);
+        changeState(PageState.success);
         /* 
         The table after the 1st scroll may be incomplete as the async API call
         is not finished. If we stop there, the bottom portion of the examples will
@@ -205,7 +206,7 @@ export function AnalysisTable({ systemID, task, cases }: Props) {
     users will not experience a delay due to the async API call.
     */
     tableRef.current?.scrollIntoView();
-  }, [systemID, page, pageSize, cases]);
+  }, [systemID, page, pageSize, cases, changeState]);
 
   // other fields
   if (systemOutputs.length === 0) {
@@ -260,7 +261,6 @@ export function AnalysisTable({ systemID, task, cases }: Props) {
       ref={tableRef}
       columns={columns}
       dataSource={dataSource}
-      loading={pageState === PageState.loading}
       rowKey="id"
       size="small"
       pagination={{

--- a/frontend/src/components/Analysis/types.tsx
+++ b/frontend/src/components/Analysis/types.tsx
@@ -28,19 +28,6 @@ export interface ResultFineGrainedParsed {
   cases: number[][];
 }
 
-/** Examples to be shown in the analysis table when a bar is clicked */
-export interface ActiveSystemExamples {
-  // invariant information across systems
-  // but depends on which bar or graph is clicked.
-  title: string;
-  barIndex: number;
-
-  // system-dependent information across systems
-  systemIndex: number;
-  /** bucket of analysis cases */
-  bucketOfCasesList: AnalysisCase[][];
-}
-
 export interface SystemInfoFeatureBucketInfo {
   method: string;
   number: number;


### PR DESCRIPTION
part of #333 

This PR refactors three components: `MetricPane`, `FineGrainedBarChart` and `ExampleTable`. `MetricPane` is a parent component of `FineGrainedBarChart` and `ExampleTable`. 

To display the examples when a bar is clicked in `FineGrainedBarChart`, we need to make two requests. We first need to get the case data via **/systems/{system_id}/cases** and then we use the sampleIDs of the cases to get sample data from **/systems/{system_id}/outputs**. The selected bar and the selected samples were stored in `activeSystemExamples`.

**Before the change**, `activeSystemExamples` is a state of `MetricPane`. It is passed to `ExampleTable` so it can display the data stored in this object. `setActiveSystemExamples` is passed to both `FineGrainedBarChart` and `ExampleTable`. `FineGrainedBarChart` updates `activeSystemExamples` to reflect the selected bar. It also makes requests to get case data and store it in `activeSystemExamples`. `ExampleTable` updates `activeSystemExamples` to reflect the selected system. This implementation is difficult to understand because all three components need to use and update `activeSystemExamples` which is a complex concept.

**After the change**, `activeSystemExamples` is split into `selectedBar` and `selectedCases`. The former keeps track of the selected bar which is only relevant to `FineGrainedBarChart`. The latter keeps track of the selected cases which is only relevant to `ExampleTable`. As a result, `FineGrainedBarChart` only needs to know how to display the bar charts, and `ExampleTable` only needs to know how to display the cases given the case details. Neither of them cares about the selected metric/feature bar concept. Additionally, `MetricPane` becomes the only component that can update `selectedBar` and `selectedCases`. If the subcomponents need to update the two states, they invoke a callback function provided by `MetricPane`. This makes it clear what triggers the state changes.

As a bonus, I added a global spinner for `MetricPane`. Before the change, **GET /systems/{system_id}/cases** doesn't trigger the spinner so the user needs to wait some time before something happens on the UI. Now, the spinner is triggered as soon as `FineGrainedBarChart` gets a bar click event.

Also fixed a small bug related to the default metric selected.

cc @noelchen90 because this is related to the example table feature you are working on.