### PR TITLE
Bugfix: show sentence in NER exampleTable

### DIFF
--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -108,7 +108,7 @@ function specifyDataSeqLab(
 
     for (let i = 0; i < systemOutputs.length; i++) {
       // Get the outputs from the bucket case
-      const origToks = systemOutputs[i][cases[i]["orig_str"]];
+      const origToks = systemOutputs[i]["tokens"];
       let sentence = origToks;
       const pos = cases[i]["token_span"];
       if (Array.isArray(origToks)) {


### PR DESCRIPTION
Closes #361

The issue with the implementation before was that it called the wrong property and thus the sentence returned empty.
This PR fixes this problem and returns a sentence. The table should now look correct.

<img width="1020" alt="截圖 2022-10-02 下午5 08 47" src="https://user-images.githubusercontent.com/36850051/193476362-e287d4c9-5cb3-4413-8adb-77ea33013ee6.png">
This screenshot is from one of my private system outputs for conll2003 (NER)