### PR TITLE
Run CI in pull request builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Continuous Integration
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: ["**"]
 
 jobs:
   build:


### PR DESCRIPTION
It's better to set up CI jobs in pull request builds as a safeguard to prevent changes that skipped pre-commit hooks from accidentally sneaking into `main`. This PR brings the same configuration from ExplainaBoard's `ci.yml`.