### PR TITLE
Set up pre-commit hook and CI to run Markdown linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,15 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: upgrade-type-hints --all-files
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: lint
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: markdownlint-cli2 --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Continuous Integration
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: ["**"]
 
 jobs:
   build:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+MD013:
+  # Number of characters
+  line_length: 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black.git
-    rev: 22.3.0 
+    rev: 22.3.0
     hooks:
       - id: black
         files: '\.py$'
@@ -31,3 +31,7 @@ repos:
         additional_dependencies:
           - types-requests
         files: '\.py$'
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.5.1
+    hooks:
+    - id: markdownlint-cli2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ExplainaBoard Web
 
-This repository includes code for frontend and backend of the ExplainaBoard web application. The frontend is built with React and the backend uses Flask.
+This repository includes code for frontend and backend of the ExplainaBoard web
+application. The frontend is built with React and the backend uses Flask.
 
 [Contribution Guide](https://docs.google.com/document/d/1Pfpg1AnrrFHVBya2Io-W2a8wRFnY9V7nN8FEYSufqCE/edit#)
 
@@ -8,19 +9,24 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 
 ## Quick Start for Developers
 
-> This step-by-step guide assumes a Linux environment. A MacOS environment will likely work similarly. For Windows users, the easiest way is to
-> use a subsystem, for example [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) (pre-installed since Windows 10).
+> This step-by-step guide assumes a Linux environment. A MacOS environment will likely
+  work similarly. For Windows users, the easiest way is to
+> use a subsystem, for example [WSL](https://docs.microsoft.com/en-us/windows/wsl/about)
+ (pre-installed since Windows 10).
 
 1. Install `node` and `npm`
 
-   - The recommended way is to install [nvm](https://github.com/nvm-sh/nvm) and use nvm to manage node versions.
-     Run `nvm install` to install node and npm.
+   - The recommended way is to install [nvm](https://github.com/nvm-sh/nvm) and use nvm
+     to manage node versions. Run `nvm install` to install node and npm.
 
-2. Make sure `java` is installed correctly in your environment. Verify this by running `java --version`.
+2. Make sure `java` is installed correctly in your environment. Verify this by running
+   `java --version`.
 3. Generate code for API layer
 
-   - Run `npm run gen-api-code` to generate code for api layer (both server and client). Please remember to run this whenever open API definition changes.
-     - We assume your computer already has `wget` and `realpath` command installed. If not found, please install by:
+   - Run `npm run gen-api-code` to generate code for api layer (both server and client).
+     Please remember to run this whenever open API definition changes.
+     - We assume your computer already has `wget` and `realpath` command installed.
+       If not found, please install by:
        - for `wget`
          - MacOS Users: `brew install wget`
          - Ubuntu Users: `sudo apt-get install wget`
@@ -31,69 +37,110 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 4. Setup dev environment for the frontend
    1. Install project dependencies `npm install`
    2. Install frontend dependencies `npm --prefix frontend install`
-      - Check the FAQ section if `npm` said there are vulnerabilities to verify if they are false alarms.
+      - Check the FAQ section if `npm` said there are vulnerabilities to verify if they
+        are false alarms.
 5. Setup dev environment for the backend
    1. Install `python` version >= 3.9.7 and create a venv or conda environment for this project
       - Official documents of connexion says `3.6` but tested on `3.9.7` seems to work fine.
    2. `pip install -r backend/src/gen/requirements.txt`
-   3. Create `backend/src/impl/.env` to store all environment variables. An example has been provided in `.env.example`. Contact the dev team to get the credentials for dev and prod environments.
+   3. Create `backend/src/impl/.env` to store all environment variables. An example has
+      been provided in `.env.example`. Contact the dev team to get the credentials for
+      dev and prod environments.
    4. Set up a GCP account and authenticate locally:
-      - Contact the dev team to setup a GCP account with access to the dev bucket of Cloud Storage.
-      - Install gcloud and then run `gcloud auth application-default login` to login to the user account locally. (for more information, see this [guide](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-user-cred))
+      - Contact the dev team to setup a GCP account with access to the dev bucket of
+        Cloud Storage.
+      - Install gcloud and then run `gcloud auth application-default login` to login to
+        the user account locally. (for more information, see this
+        [guide](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-user-cred))
       - Set project by running `gcloud config set project inspired-app-eb-dev`
 6. Install pre-commit hooks
-   - Run `npm run prepare` to install the pre-commit hook via husky. The hook auto-checks both frontend and backend code before commits. Please do not skip it.
+   - Run `npm run prepare` to install the pre-commit hook via husky. The hook
+     auto-checks both frontend and backend code before commits. Please do not skip it.
 7. Launch explainaboard
    1. Run `npm run start` to start the frontend and backend server concurrently.
-      - Both frontend and backend can be started independently as well. Check out "More details on frontend and backend".
+      - Both frontend and backend can be started independently as well. Check out
+        "More details on frontend and backend".
 
 ## Important notes on local development
 
-- As mentioned in quick start step 2, whenever the open API definition (openapi.yaml) changes, you must run `npm run gen-api-code` to regenerate code for the api layer.
-- The frontend and backend dependencies must be reinstalled whenever the associated dependency files are changed, including `package.json`, `frontend/package.json`, `backend/src/gen/requirements.txt` (generated from `backend/templates/requirements.mustache`).
-- ExplainaBoard API client release depends on the API defined in `openapi.yaml`. If `openapi.yaml` is changed, remember to bump up the openapi version `0.2.x` as well.
+- As mentioned in quick start step 2, whenever the open API definition (openapi.yaml)
+  changes, you must run `npm run gen-api-code` to regenerate code for the api layer.
+- The frontend and backend dependencies must be reinstalled whenever the associated
+  dependency files are changed, including `package.json`, `frontend/package.json`,
+  `backend/src/gen/requirements.txt` (generated from
+  `backend/templates/requirements.mustache`).
+- ExplainaBoard API client release depends on the API defined in `openapi.yaml`. If
+  `openapi.yaml` is changed, remember to bump up the openapi version `0.2.x` as well.
 
 ## Deployment
 
-- We use docker and gunicorn to deploy both frontend and backend. Frontend is built and copied into the static file folder of Flask. Please see Dockerfile for details.
+- We use docker and gunicorn to deploy both frontend and backend. Frontend is built and
+  copied into the static file folder of Flask. Please see Dockerfile for details.
 - To build: `docker build --pull --rm -f "Dockerfile" -t explainaboard-web:0.2.0 "."`
 - To run: `docker run --rm -p 5000:5000/tcp explainaboard-web:0.2.0`
 - GCP:
-  - For local development, developers should use their own user accounts to authenticate (please refer to quick start for details)
-  - For staging and production environments, the service account credentials are passed into the containers as environment variables. The credentials are stored on AWS Secrets Manager.
+  - For local development, developers should use their own user accounts to authenticate
+    (please refer to quick start for details)
+  - For staging and production environments, the service account credentials are passed
+    into the containers as environment variables. The credentials are stored on AWS
+    Secrets Manager.
 
 ## More details on frontend and backend
 
 1. Frontend:
 
    1. To start frontend dev server only, run `npm run start-frontend`
-      - Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in the browser. The page will reload if you make edits. You will also see any lint errors in the console.
+      - Runs the app in the development mode. Open
+        [http://localhost:3000](http://localhost:3000) to view it in the browser. The
+        page will reload if you make edits. You will also see any lint errors in the
+        console.
    2. linter and formatter
-      - eslint is used for linting. Please install eslint VSCode extension to get immediate feedback while writing code.
+      - eslint is used for linting. Please install eslint VSCode extension to get
+        immediate feedback while writing code.
         - configurations can be found in `.eslintignore` and `.eslintrc.json`
         - `npm run lint` runs eslint in the commandline
-      - prettier is used for formatting. Please install prettier VSCode extension and enable format on save to get the best results.
+      - prettier is used for formatting. Please install prettier VSCode extension and
+        enable format on save to get the best results.
         - configurations can be found in `.prettierignore` and `.prettierrc.json`
-      - linting and formatting is enforced automatically at the "pre-commit" stage with husky. Please do not skip it. If you find a rule particularly annoying, please post in Slack and we can remove it.
-      - eslint and prettier should not be applied on the python code (backend). I should have already configured both of the tools to ignore python. Please let me know if you think something isn't working properly.
+      - linting and formatting is enforced automatically at the "pre-commit" stage with
+        husky. Please do not skip it. If you find a rule particularly annoying, please
+        post in Slack and we can remove it.
+      - eslint and prettier should not be applied on the python code (backend). I should
+        have already configured both of the tools to ignore python. Please let me know
+        if you think something isn't working properly.
    3. Testing
-      - `npm test` launches the test runner in the interactive watch mode. See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+      - `npm test` launches the test runner in the interactive watch mode. See the
+        section about
+        [running tests](https://facebook.github.io/create-react-app/docs/running-tests)
+        for more information.
    4. Build `npm run build`
 
       - You do not need to run this manually. It is handled automatically by the docker file.
-      - Builds the app for production to the `build` folder. It correctly bundles React in production mode and optimizes the build for the best performance.
-      - See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+      - Builds the app for production to the `build` folder. It correctly bundles React
+        in production mode and optimizes the build for the best performance.
+      - See the section about
+        [deployment](https://facebook.github.io/create-react-app/docs/deployment) for
+        more information.
 
    5. Frontend is created with [Create React App](https://github.com/facebook/create-react-app).
 
       - A note about `npm run eject`
         **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
-        If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+        If you aren’t satisfied with the build tool and configuration choices, you can
+        `eject` at any time. This command will remove the single build dependency from
+        your project.
 
-        Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+        Instead, it will copy all the configuration files and the transitive
+        dependencies (webpack, Babel, ESLint, etc) right into your project so you have
+        full control over them. All of the commands except `eject` will still work, but
+        they will point to the copied scripts so you can tweak them. At this point
+        you’re on your own.
 
-        You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+        You don’t have to ever use `eject`. The curated feature set is suitable for
+        small and middle deployments, and you shouldn’t feel obligated to use this
+        feature. However we understand that this tool wouldn’t be useful if you couldn’t
+        customize it when you are ready for it.
 
       - You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
@@ -101,13 +148,15 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 
 2. Backend
    1. To start backend server only, run `npm run start-backend`
-      - Listens on port 5000. Frontend is configured to send all API requests to 5000 via a proxy.
-      - Any code not in `impl` is generated. If you want to modify the generated code, you need to modify the mustache templates.
+      - Listens on port 5000. Frontend is configured to send all API requests to 5000
+        via a proxy.
+      - Any code not in `impl` is generated. If you want to modify the generated code,
+        you need to modify the mustache templates.
    2. For details of the backend, please refer to `README.md` under `backend/`.
 
 ## Project Structure
 
-```
+```text
 - .husky # for running pre-commit checks
 - openapi
    - openapi.yaml # api specifications
@@ -129,14 +178,16 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 - backend
    - templates # mustache templates to generate template code
    - src
-      - gen # template code generated with openapi, code in this folder should not be modified manually
+      - gen # template code generated with openapi, code in this folder should not be
+            # modified manually
          - requirements.txt
          - explainaboard
             - __main__.py
             - controllers
             - test
             - models
-            - impl # a sympolic link to the impl folder, any edition made here will "reflect" on the impl folder
+            - impl # a sympolic link to the impl folder, any edition made here will
+                   # "reflect" on the impl folder
       - impl # our implementation of the apis
 
 - .gitignore
@@ -148,14 +199,21 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 
 ## FAQ
 
-#### `npm install --prefix frontend` says we have x vulnerabilities
+### `npm install --prefix frontend` says we have x vulnerabilities
 
-Solution: Run `npm audit --prefix frontend --production`. If it says 0 vulnerabilities, we are fine.
+Solution: Run `npm audit --prefix frontend --production`. If it says 0 vulnerabilities,
+we are fine.
 
-Reason: We use create react app for frontend, and the `react-scripts` dependency in `frontend/package.json` is causing these false alarms.
-[Here's](https://github.com/facebook/create-react-app/issues/11174) the moderator of create react app explaining why 99.9% of the vulnerability reports in react-scripts are false positives and how to fix them.
+Reason: We use create react app for frontend, and the `react-scripts` dependency in
+`frontend/package.json` is causing these false alarms.
+[Here's](https://github.com/facebook/create-react-app/issues/11174) the moderator of
+create react app explaining why 99.9% of the vulnerability reports in react-scripts are
+false positives and how to fix them.
 
 ## Credits/Contributing
 
-This software was initially developed by Lyuyang Hu, Chih-Hao Wang, Pengfei Liu, and Graham Neubig, a collaborative effort of Carnegie Mellon University and Inspired Cognition Inc.
-We highly welcome questions, issues, and pull requests. Please get in contact through github issues above.
+This software was initially developed by Lyuyang Hu, Chih-Hao Wang, Pengfei Liu, and
+Graham Neubig, a collaborative effort of Carnegie Mellon University and Inspired
+Cognition Inc.
+We highly welcome questions, issues, and pull requests. Please get in contact through
+github issues above.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,12 +1,12 @@
 # ExplainaBoard Web Backend
 
-This folder includes code for backend of the ExplainaBoard web application. 
+This folder includes code for backend of the ExplainaBoard web application.
 
 ## Getting Started
 
-1.  Project Structure
+1. Project Structure
 
-    ```
+    ```text
     - src/
         - gen/ # code generated using swagger. DO NOT edit anything here. gitignored.
         - impl/ # our own code and implementations.
@@ -14,63 +14,100 @@ This folder includes code for backend of the ExplainaBoard web application.
     - README.md
     ```
 
-2.  Usage
+2. Usage
 
     1. Run `npm run gen-api-code` to generate python flask server code under `src/gen/`
 
-    2. Refer to `src/gen/README.md` to start the server. Alternatively, run `npm run start-backend` in the repo root directory (one level above here.)
+    2. Refer to `src/gen/README.md` to start the server. Alternatively, run
+       `npm run start-backend` in the repo root directory (one level above here.)
 
 ## Developer Guide
 
 ### Swagger code generation process
+
 There are three main components used in code generation:
+
 1. swagger codegen cli (in `.jar` format): The swagger tool for code generation.
 
 2. `openapi.yaml`: The api specification that swagger reads to generate corresponding code.
 
-3. `.mustache` files under `templates/`: Template files are used to generate the actual files under `src/gen` by swagger. E.g., `templates/README.mustache` -> `src/gen/README.md`, `templates/model.mustache` -> the `.py` files under `src/gen/models.`
+3. `.mustache` files under `templates/`: Template files are used to generate the actual
+   files under `src/gen` by swagger. E.g.,
+   `templates/README.mustache` -> `src/gen/README.md`,
+   `templates/model.mustache` -> the `.py` files under `src/gen/models.`
 
-We can edit `openapi.yaml` and the template `.mustache` files to customize the generated code.
+We can edit `openapi.yaml` and the template `.mustache` files to customize the generated
+code.
 
 ### Separation of generated code and our own code
+
 **Issue:**
 
-Because the generated code under `src/gen` is only a skeleton, it does not contain details such as core logic, db connections, etc. This means we must add our own code. However, after adding our code, if we modify the openapi schema (e.g. add a new api path) and re-generate, we will end up overwriting our existing code.
+Because the generated code under `src/gen` is only a skeleton, it does not contain
+details such as core logic, db connections, etc. This means we must add our own code.
+However, after adding our code, if we modify the openapi schema
+(e.g. add a new api path) and re-generate, we will end up overwriting our existing code.
 
 **Solution:**
 
-To separate the generated code and our own code, we follow an approach similar to [this answer on stackoverflow](https://stackoverflow.com/questions/45680298/cleanest-way-to-glue-generated-flask-app-code-swagger-codegen-to-backend-imple/47554626#47554626):
+To separate the generated code and our own code, we follow an approach similar to
+[this answer on stackoverflow](https://stackoverflow.com/questions/45680298/cleanest-way-to-glue-generated-flask-app-code-swagger-codegen-to-backend-imple/47554626#47554626):
 
 1. store all generated code under `src/gen` and our own code under `src/impl`.
-2. create a symbolic link to `src/impl` under `src/gen/explainaboard` every time in code generation. See `openapi/gen_api_layer.sh` for details.
-3. In `templates/controller.mustache`, add 
+2. create a symbolic link to `src/impl` under `src/gen/explainaboard` every time in code
+   generation. See `openapi/gen_api_layer.sh` for details.
+3. In `templates/controller.mustache`, add
+   ```import {{packageName}}.impl.default_controllers_impl as default_controllers_impl```
+   to import `src/impl/default_controllers_impl.py`, which contains our own logic for
+   handling requests.
 
-```import {{packageName}}.impl.default_controllers_impl as default_controllers_impl```  
+4. In `templates/controller.mustache`, add
 
-to import `src/impl/default_controllers_impl.py`, which contains our own logic for handling requests. 
+   ```python
+   return default_controllers_impl.{{operationId}}(
+       {{#parameters}}{{paramName}}{{^required}}=None{{/required}}{{#hasMore}}, {{/hasMore}}{{/parameters}}
+   )
+   ```
 
-4. In `templates/controller.mustache`, add  
-
-```return default_controllers_impl.{{operationId}}({{#parameters}}{{paramName}}{{^required}}=None{{/required}}{{#hasMore}}, {{/hasMore}}{{/parameters}})```
-
-such that it calls our own function and passes in the request parameters.
-
+   such that it calls our own function and passes in the request parameters.
 
 ## Python Client
-A python client is generated based on openapi.yaml and it is released as `explainaboard_api_client` on PyPI. We also maintain a thin wrapper for the client `explainaboard_client` ([source code](https://github.com/neulab/explainaboard_client)). Users generally use the wrapper package because it handles low level configurations for them.
-- version: determined by `info.version` in openapi.yaml. Please remember to update the version whenever you change the openapi definition. If openapi.yaml is modified but the version number has been used in an old version, "Python API Client Release" will fail to flag that error.
-- codegen tool: [openapi generator](https://github.com/OpenAPITools/openapi-generator) 5.4.0. We use a different codegen tool for the python client from the backend (flask) and the TS client because openapi generator provides better support for generating python clients. We plan to migrate to openapi generator for all languages/frameworks in the future because it provides much better documentation and more features.
-- template: stored in `openapi/python_client_urllib3_templates`. We only applied minor modifications (better type hint) to the template provided by openapi generator. The original template can be fetched with `java -jar openapi-generator-cli.jar author template -g python`. When openapi generator release a new version of the template, we can merge our version with theirs.
-  - two options are available for python clients: `python` and `python-experimental`. `python-experimental` provides better typing but it is buggy and difficult to work with. So, currently, we use the `python` template. There's limited type hint but it's relatively easy to figure out the input and outputs from the docstrings.
+
+A python client is generated based on openapi.yaml and it is released as
+`explainaboard_api_client` on PyPI. We also maintain a thin wrapper for the client
+`explainaboard_client` ([source code](https://github.com/neulab/explainaboard_client)).
+Users generally use the wrapper package because it handles low level configurations for
+them.
+
+- version: determined by `info.version` in openapi.yaml. Please remember to update the
+  version whenever you change the openapi definition. If openapi.yaml is modified but
+  the version number has been used in an old version, "Python API Client Release" will
+  fail to flag that error.
+- codegen tool: [openapi generator](https://github.com/OpenAPITools/openapi-generator)
+  5.4.0. We use a different codegen tool for the python client from the backend (flask)
+  and the TS client because openapi generator provides better support for generating
+  python clients. We plan to migrate to openapi generator for all languages/frameworks
+  in the future because it provides much better documentation and more features.
+- template: stored in `openapi/python_client_urllib3_templates`. We only applied minor
+  modifications (better type hint) to the template provided by openapi generator. The
+  original template can be fetched with
+  `java -jar openapi-generator-cli.jar author template -g python`. When openapi
+  generator release a new version of the template, we can merge our version with theirs.
+  - two options are available for python clients: `python` and `python-experimental`.
+    `python-experimental` provides better typing but it is buggy and difficult to work
+    with. So, currently, we use the `python` template. There's limited type hint but
+    it's relatively easy to figure out the input and outputs from the docstrings.
   - generated code follows the following structure:
-  ```
-  - /docs: documentation for each data structure and API
-  - /explainaboard_api_client:
-    - /api
-      - default_api.py  # implements all the endpoints specified in openapi.yaml
-    - /model            # implements all the data structures
-    - /models           # exports all models defined in /model
-    - api_client.py     # implements the base API client (async&sync requests, error handling, etc.); used by default_api.py
-    - configuration.py  # configurations for api_client (auth, hostname, etc.)
-    - exceptions.py     # client exceptions
-  ```
+
+    ```text
+    - /docs: documentation for each data structure and API
+    - /explainaboard_api_client:
+      - /api
+        - default_api.py  # implements all the endpoints specified in openapi.yaml
+      - /model            # implements all the data structures
+      - /models           # exports all models defined in /model
+      - api_client.py     # implements the base API client (async&sync requests, error
+                          # handling, etc.); used by default_api.py
+      - configuration.py  # configurations for api_client (auth, hostname, etc.)
+      - exceptions.py     # client exceptions
+    ```


### PR DESCRIPTION
Currently, there is no linter to check Markdown files automatically. It's better to lint Markdown files for both reviewers' time and time of authors of pull requests. It's challenging to maintain the style of the format. Manually checking by humans can be exhausting. This PR addresses the issue by setting up pre-commit hook and CI to run a Markdown linter, [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2). Also, this PR fixes issues found by the linter to keep the CI build green (mostly just break too long lines into multiple lines)

Note that the project specific configuration is configured in `.pre-commit-config.yaml`. More configuration can be added based on code owner's preference. For now, the configuration file only contains the line length limit to 88, blindly following the line length for Python code. 