### PR TITLE
Download swagger-codegen jar file more quietly for CI

### DIFF
--- a/openapi/gen_api_layer.sh
+++ b/openapi/gen_api_layer.sh
@@ -16,7 +16,7 @@ FRONTEND_GEN_PATH="frontend/src/clients/openapi"
 # download codegen cli if not exists
 cd $script_dir
 if [ ! -f swagger-codegen-cli-3.0.29.jar ]; then
-    wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.29/swagger-codegen-cli-3.0.29.jar -O swagger-codegen-cli-3.0.29.jar
+    wget --progress=dot:giga https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.29/swagger-codegen-cli-3.0.29.jar -O swagger-codegen-cli-3.0.29.jar
 fi
 
 


### PR DESCRIPTION
Currently, a CI job `build` downloads swagger-codegen jar file using `wget` for code generation. `wget` command prints out the progress to stdout. The output contains about 400 lines, which is a bit long. This PR reduces the output to 12 lines by running `wget` with `--progress=dot:giga` (See the [manual of wget](https://www.gnu.org/software/wget/manual/wget.html#Download-Options) for details). Alternatively, we can turn off the output by setting `--no-verbose` which still prints error messages. If we need to reduce the output further, we can consider setting that option.