### PR TITLE
Gets the absolute path to openapi directory without realpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,10 @@ This repository includes code for frontend and backend of the ExplainaBoard web 
 3. Generate code for API layer
 
    - Run `npm run gen-api-code` to generate code for api layer (both server and client). Please remember to run this whenever OpenAPI definition changes.
-     - We assume your computer already has `wget` and `realpath` command installed. If not found, please install by:
+     - We assume your computer already has `wget` command installed. If not found, please install by:
        - for `wget`
          - MacOS Users: `brew install wget`
          - Ubuntu Users: `sudo apt-get install wget`
-       - for `realpath`
-         - MacOS Users: `brew install coreutils`
-         - Ubuntu Users: `sudo apt-get install coreutils`
 
 4. Setup dev environment for the frontend
    1. Install project dependencies `npm install`

--- a/openapi/gen_api_layer.sh
+++ b/openapi/gen_api_layer.sh
@@ -6,7 +6,7 @@ set -e
 
 # three modes: generate frontend only, backend only and both
 mode=$1
-script_dir=`dirname "$(realpath $0)"`
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 project_root=`dirname $script_dir`
 
 OPENAPI_PATH="openapi"


### PR DESCRIPTION
Currently, `openapi/gen_api_layer.sh` requires developers to install `realpath` command to get the absolute path to `openapi` directory. That's easier to install on some Linux distributions such as Ubuntu, but on macOS, it requires installing Homebrew first (That's pretty common, but periodically updating softwares itself is a maintenance burden because it builds a different world). It's better to avoid installing additional tools if possible. This PR changes how to get the absolute path in a more portable way without requiring `realpath` command.