### PR TITLE
Remove documentation on supported Python version of connexion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ application. The frontend is built with React and the backend uses Flask.
         are false alarms.
 5. Setup dev environment for the backend
    1. Install `python` version >= 3.9.7 and create a venv or conda environment for this project
-      - Official documents of connexion says `3.6` but tested on `3.9.7` seems to work fine.
    2. `pip install -r backend/src/gen/requirements.txt`
    3. Create `backend/src/impl/.env` to store all environment variables. An example has
       been provided in `.env.example`. Contact the dev team to get the credentials for


### PR DESCRIPTION
Currently, [connexion v2.10.0 was already tested against Python 3.9](https://github.com/spec-first/connexion/blob/2.10.0/.github/workflows/pipeline.yml#L12). There's no strong reason to mention the supported version of connection. It seems developers of connection forgot to add Python 3.9 to `setup.py` until v2.11.1.