### PR TITLE
Use curl instead of wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM node:14-bullseye-slim as build-step
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
-RUN apt-get update && apt-get install -y default-jre wget
+RUN apt-get update && apt-get install -y default-jre curl
 RUN mkdir ./frontend
 COPY ./frontend/package.json ./frontend/package-lock.json ./frontend/
 WORKDIR /app/frontend
@@ -24,7 +24,7 @@ RUN npm run build
 
 # Step #2: build the API with the client as static files
 FROM python:3.9-slim-bullseye
-RUN apt-get update && apt-get install -y default-jre wget nginx
+RUN apt-get update && apt-get install -y default-jre curl nginx
 
 WORKDIR /app
 RUN python3 -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ application. The frontend is built with React and the backend uses Flask.
 
    - Run `npm run gen-api-code` to generate code for api layer (both server and client).
      Please remember to run this whenever OpenAPI definition changes.
-     - We assume your computer already has `wget` command installed. If not found,
-       please install by:
-       - for `wget`
-         - MacOS Users: `brew install wget`
-         - Ubuntu Users: `sudo apt-get install wget`
 
 4. Setup dev environment for the frontend
    1. Install project dependencies `npm install`

--- a/openapi/gen_api_layer.sh
+++ b/openapi/gen_api_layer.sh
@@ -13,10 +13,15 @@ OPENAPI_PATH="openapi"
 BACKEND_GEN_PATH="backend/src/gen"
 FRONTEND_GEN_PATH="frontend/src/clients/openapi"
 
+if ! [ `which curl` ]; then
+    echo "ERROR: curl not found. Please install curl command."
+    exit 1
+fi
+
 # download codegen cli if not exists
 cd $script_dir
 if [ ! -f swagger-codegen-cli-3.0.29.jar ]; then
-    wget --progress=dot:giga https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.29/swagger-codegen-cli-3.0.29.jar -O swagger-codegen-cli-3.0.29.jar
+    curl -L -O https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.29/swagger-codegen-cli-3.0.29.jar
 fi
 
 


### PR DESCRIPTION
This PR uses `curl` command instead of `wget` for downloading swagger-codegen jar file to simplify the setup because `curl` is installed by default on macOS. There is no need to install `wget` with Homebrew. For Linux users, `openapi/gen_api_layer.sh` should just report error messages if `curl` is missing (I think we don't need to teach every single detail on how to install the very popular software).