### PR TITLE
Use relative link to backend/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ application. The frontend is built with React and the backend uses Flask.
         via a proxy.
       - Any code not in `impl` is generated. If you want to modify the generated code,
         you need to modify the mustache templates.
-   2. For details of the backend, please refer to `README.md` under `backend/`.
+   2. For details of the backend, please refer to [backend/README.md](backend/README.md).
 
 ## Project Structure
 


### PR DESCRIPTION
This PR uses [relative link](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links) to `backend/README.md` so that readers can easily navigate to the file.