### PR TITLE
Add yamllint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,11 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: markdownlint-cli2 --all-files
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: lint
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: yamllint --all-files

--- a/.github/workflows/py-client-release.yml
+++ b/.github/workflows/py-client-release.yml
@@ -1,6 +1,6 @@
 name: "Python API Client Release"
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
     paths:
@@ -34,9 +34,11 @@ jobs:
           pip install wheel
 
       - name: generate python client
+        # yamllint disable rule:line-length
         run: |
           wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.4.0/openapi-generator-cli-5.4.0.jar -O openapi-generator-cli.jar
           java -jar openapi-generator-cli.jar generate -i openapi/openapi.yaml -g python -o python_client -t "openapi/python_client_urllib3_templates" "--additional-properties=packageName=explainaboard_api_client,packageVersion=${{ steps.extract_version.outputs.version }}"
+        # yamllint enable
 
       - name: build
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,8 @@ repos:
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.5.1
     hooks:
-    - id: markdownlint-cli2
+      - id: markdownlint-cli2
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.28.0
+    hooks:
+      - id: yamllint

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  line-length:
+    max: 88
+  document-start: disable
+  truthy:
+    level: error

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -36,7 +36,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TaskCategory"
-  
+
   /languagecodes:
     get:
       summary: Return all language codes
@@ -51,7 +51,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/LanguageCode"
-  
+
   /benchmarkconfigs:
     get:
       summary: Returns all benchmark configs matching the specification
@@ -79,7 +79,7 @@ paths:
       summary: Returns benchmark metadata by id
       operationId: benchmarkGetById
       security: []
-      description: Returns benchmark metadata by id. 
+      description: Returns benchmark metadata by id.
       parameters:
         - in: path
           name: benchmark_id
@@ -87,12 +87,12 @@ paths:
           schema:
             type: string
           required: true
-        - in: query 
-          name: by_creator 
-          example: True 
-          schema: 
-            type: boolean 
-          required: true 
+        - in: query
+          name: by_creator
+          example: true
+          schema:
+            type: boolean
+          required: true
       responses:
         "200":
           description: OK
@@ -106,14 +106,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/APIError"
-          
+
 
   /datasets/{dataset_id}:
     get:
       summary: Returns dataset metadata by id
       operationId: datasetsGetById
       security: []
-      description: Returns dataset metadata by id. id is the DB id so it is mostly used internally. See datasets MGet endpoints for general use.
+      description: |
+        Returns dataset metadata by id. id is the DB id so it is mostly used internally.
+        See datasets MGet endpoints for general use.
       parameters:
         - in: path
           name: dataset_id
@@ -140,7 +142,9 @@ paths:
       summary: Returns a list of datasets
       operationId: datasetsGet
       security: []
-      description: Returns a list of datasets. Returns empty list if current page is empty. Returns `total=0` if no match datasets.
+      description: |
+        Returns a list of datasets. Returns empty list if current page is empty.
+        Returns `total=0` if no match datasets.
       parameters:
         - in: query
           name: dataset_ids
@@ -185,7 +189,9 @@ paths:
     get:
       summary: Returns system metadata info by id
       operationId: systemsGetById
-      description: Returns a system_metadata by id. id is the DB id so it is mostly used internally.
+      description: |
+        Returns a system_metadata by id. id is the DB id so it is mostly used
+        internally.
       parameters:
         - in: path
           name: system_id
@@ -337,9 +343,9 @@ paths:
       operationId: systemOutputsGetById
       description: This will fail if the user doesn't have permissions for that system.
       security:
-        - ApiKeyAuth: [ ]
-        - BearerAuth: [ ]
-        - { }
+        - ApiKeyAuth: []
+        - BearerAuth: []
+        - {}
       parameters:
         - in: path
           name: system_id
@@ -372,9 +378,9 @@ paths:
       operationId: systemCasesGetById
       description: This will fail if the user doesn't have permissions for that system.
       security:
-        - ApiKeyAuth: [ ]
-        - BearerAuth: [ ]
-        - { }
+        - ApiKeyAuth: []
+        - BearerAuth: []
+        - {}
       parameters:
         - in: path
           name: system_id
@@ -458,7 +464,9 @@ paths:
 
   /info:
     get:
-      summary: information for environment identifier, backend version, login URL, etc. (not intent for public users)
+      summary: |
+        information for environment identifier, backend version, login URL, etc.
+        (not intent for public users)
       operationId: infoGet
       security: []
       responses:
@@ -606,10 +614,10 @@ components:
           type: string
         source_language:
           type: string
-          nullable: True
+          nullable: true
         target_language:
           type: string
-          nullable: True
+          nullable: true
         cls_name:
           type: string
       additionalProperties: true
@@ -631,7 +639,8 @@ components:
       required: [dtype, cls_name]
 
     SystemInfo:
-      description: Information about a system output, used in SDK's fine-grained analysis
+      description: |
+        Information about a system output, used in SDK's fine-grained analysis
       type: object
       properties:
         task_name:
@@ -661,7 +670,7 @@ components:
           type: number
         system_details:
           type: object
-          nullable: True
+          nullable: true
         analysis_levels:
           type: array
           items:
@@ -828,7 +837,7 @@ components:
           example: "text_classification"
         is_private:
           type: boolean
-          default: True
+          default: true
         shared_users:
           type: array
           items:
@@ -915,9 +924,12 @@ components:
               required: [dataset_id, dataset_name, tasks]
             system_details:
               type: object
-              description: a place to store arbitrary system details you want to remember
+              description: |
+                a place to store arbitrary system details you want to remember
             metric_stats:
-              description: An array of sufficient statistics for each metric, used in SDK's fine-grained analysis
+              description: |
+                An array of sufficient statistics for each metric, used in SDK's
+                fine-grained analysis
               type: array
               items:
                 type: array
@@ -1086,8 +1098,6 @@ components:
             $ref: "#/components/schemas/AnalysisResult"
       required: [analysis_results]
 
-
-
     SystemAnalysesReturn:
       type: object
       properties:
@@ -1100,7 +1110,6 @@ components:
           items:
             $ref: "#/components/schemas/SignificanceTestInfo"
       required: [system_analyses]
-
 
     Performance:
       type: object
@@ -1195,7 +1204,8 @@ components:
           type: string
         type:
           type: string
-          description: "could be 'abstract' to indicate this doesn't fully specify a benchmark"
+          description: |
+            "could be 'abstract' to indicate this doesn't fully specify a benchmark"
         parent:
           type: string
           description: "a parent benchmark that this benchmark inherits config from"
@@ -1207,10 +1217,10 @@ components:
         contact:
           type: string
         homepage:
-          type: string          
+          type: string
         paper:
-          type: object 
-          $ref: "#/components/schemas/Paper"                     
+          type: object
+          $ref: "#/components/schemas/Paper"
         metrics:
           type: array
           items:
@@ -1272,12 +1282,12 @@ components:
             items:
               type: number
         plot_y_values:
-          type: array 
+          type: array
           items:
             type: number
-        plot_x_values: 
-          type: array 
-          items: 
+        plot_x_values:
+          type: array
+          items:
             type: string
       required: [name, system_names, column_names, scores, plot_y_values, plot_x_values]
 
@@ -1290,8 +1300,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BenchmarkTableData"
-        time: 
-          type: string 
+        time:
+          type: string
       required: [config]
 
     Paper:


### PR DESCRIPTION
This PR adds [yamllint](https://github.com/adrienverge/yamllint) to pre-commit hook and CI to lint YAML files. All the issues found by yamllint are fixed manually and automatically.  yamllint is partially disabled within YAML files for GitHub Actions. This is because yamllint warns that [GitHub actions' on key](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on) should have a truthy value, but the key doesn't  (see the [documentation](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy); the same issue was discussed in e.g., adrienverge/yamllint#430).


