### PR TITLE
Use ~= in requirements file to pin the versions of Python packages

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,15 +1,15 @@
-apache-beam>=2.38.0
-boto3==1.24.68
-pymongo[srv]
-Flask-PyMongo
-python-dotenv
-pyjwt[crypto] == 2.3.0
+apache-beam~=2.41.0
+boto3~=1.24.68
+pymongo[srv]~=3.12.3
+Flask-PyMongo~=2.3.0
+python-dotenv~=0.21.0
+pyjwt[crypto] ~= 2.3.0
 explainaboard == 0.11.1
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
-pre-commit
-marisa_trie
-sacrebleu[ja]
-six
-pandas
-iso-639
-google-cloud-storage==2.5.0
+pre-commit~=2.20.0
+marisa_trie~=0.7.7
+sacrebleu[ja]~=2.2.1
+six~=1.16.0
+pandas~=1.5.0
+iso-639~=0.4.5
+google-cloud-storage~=2.5.0


### PR DESCRIPTION
As per, the [previous discussion](https://github.com/neulab/ExplainaBoard/pull/403#issuecomment-1242754774), this PR uses `~=` to pin specific versions of Python packages in the requirements file, except explainaboard. Specified versions were determined from the [logs of the CI run](https://github.com/neulab/explainaboard_web/actions/runs/3202108910/jobs/5230754631). Note that the template file `backend/templates/requirements.mustache` remains unchanged. The file uses `>=` operator, but I'm not sure whether we need to change it to `~=` or not.