### PR TITLE
Fix paper url in summverse

### DIFF
--- a/backend/src/impl/benchmark_configs/summverse.json
+++ b/backend/src/impl/benchmark_configs/summverse.json
@@ -6,7 +6,7 @@
   "homepage": null,
   "paper": {
       "title": "Summverse",
-      "url": null
+      "url": ""
   },
   "description": "Benchmark Summarization Task",
   "logo": "https://explainaboard.s3.amazonaws.com/benchmarks/figures/sumverse.png",


### PR DESCRIPTION
In the `Paper` object, `url` is a required field:
https://github.com/neulab/explainaboard_web/blob/e138432bc3d17c734dbbd4be08d362150ac32c07/openapi/openapi.yaml#L1314

But it was missing in the summverse benchmark, causing errors. This commit makes a minimal fix by changing summverse to the empty string.