### PR TITLE
Globalbench fixes

### DIFF
--- a/backend/src/impl/benchmark_configs/globalbench_ner.json
+++ b/backend/src/impl/benchmark_configs/globalbench_ner.json
@@ -7,6 +7,6 @@
     "type": "standard",
     "metrics": [{"name": "F1"}],
     "system_query": {
-        "task": "named-entity-recognition"
+        "task_name": "named-entity-recognition"
     }
 }

--- a/backend/src/impl/benchmark_configs/globalbench_qa-extractive.json
+++ b/backend/src/impl/benchmark_configs/globalbench_qa-extractive.json
@@ -7,6 +7,6 @@
     "type": "standard",
     "metrics": [{"name": "F1"}, {"name": "ExactMatch"}],
     "system_query": {
-        "task": "qa-extractive"
+        "task_name": "qa-extractive"
     }
 }

--- a/backend/src/impl/benchmark_configs/globalbench_tpc.json
+++ b/backend/src/impl/benchmark_configs/globalbench_tpc.json
@@ -7,6 +7,6 @@
     "type": "standard",
     "metrics": [{"name": "Accuracy"}],
     "system_query": {
-        "task": "text-pair-classification"
+        "task_name": "text-pair-classification"
     }
 }

--- a/backend/src/impl/benchmark_configs/summverse.json
+++ b/backend/src/impl/benchmark_configs/summverse.json
@@ -6,7 +6,7 @@
   "homepage": null,
   "paper": {
       "title": "Summverse",
-      "url": null
+      "url": ""
   },
   "description": "Benchmark Summarization Task",
   "logo": "https://explainaboard.s3.amazonaws.com/benchmarks/figures/sumverse.png",

--- a/backend/src/impl/benchmark_utils.py
+++ b/backend/src/impl/benchmark_utils.py
@@ -84,9 +84,11 @@ class BenchmarkUtils:
         systems = systems_return.systems
         for system in systems:
             temp = system.system_info.to_dict()
-            temp["creator"] = system.creator.split("@")[0]
-            temp["created_at"] = system.created_at
-            sys_infos.append(temp)
+            # Don't include systems with no dataset
+            if temp["dataset_name"] is not None:
+                temp["creator"] = system.creator.split("@")[0]
+                temp["created_at"] = system.created_at
+                sys_infos.append(temp)
         return sys_infos
 
     @staticmethod


### PR DESCRIPTION
This makes two fixes to fix the GlobalBench benchmark:

1. skip system results without a dataset_name (custom datasets)
2. rename 'task' to 'task_name' to match the new schema

Should be reviewed after https://github.com/neulab/explainaboard_web/pull/391