### PR TITLE
Fix yamllint error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
           path: |
             node_modules
             frontend/node_modules
+          # yamllint disable rule:line-length
           key: node-${{ hashFiles('.nvmrc', 'package-lock.json', 'frontend/package-lock.json') }}
+          # yamllint enable
       - name: Install node components
         run: |
           npm run gen-api-code


### PR DESCRIPTION
This PR fixes CI. Currently, yamllint job is failing because #374 was merged after #388. #374 adds a line which is longer than 88 column limit. This PR fixes the error by suppressing the error.