### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owner
+* @neubig @lyuyangh


### PR DESCRIPTION
This PR adds `CODEOWNERS` file to define persons that are responsible for code in this repository. See #387 for how I picked up code owners. We could add more fine-grained code owners per directory later if necessary.

Closes #387.
