### PR TITLE
Use a config file for markdowlint-cli2 rather than markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,4 @@
+config:
+  MD013:
+    # Number of characters
+    line_length: 88

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,0 @@
-MD013:
-  # Number of characters
-  line_length: 88


### PR DESCRIPTION
This PR changes the config file format for the Markdown linter CLI, `markdowlint-cli2` from `.markdownlint.yaml` to `.markdownlint-cli2.yaml`. This is because markdownlint-cli2 supports  two different types of configuration file format: one for the library `markdownlint` (e.g., `.markdownlint.yaml`)  and the other for the CLI (e.g., `.markdownlint-cli2.yaml`). The configuration file for the CLI has more options to configure than the configuration file for the library. For instance, the configuration file for the library doesn't allow to specify file paths to skip the linter, which is useful in the future when we need to add third party code as ExplainaBoard does. (See also neulab/explainaboard#545)