### PR TITLE
Cache pip dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
+          cache: 'pip'
       - name: Install node 14.x
         uses: actions/setup-node@v2
         with:
@@ -42,9 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
+          cache: 'pip'
       - name: Install node 14.x
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This PR caches pip dependencies to avoid fetching Python packages from PyPI rather than to speed up CI. By comparing the executions before and after caching, it looks we can save a few seconds. Note that switching to a different tool such as poetry is beyond the scope of this PR.