### PR TITLE
Add shell script linter to pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,11 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: end-of-file-fixer --all-files
+  lint-shell-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: lint
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: shellcheck --all-files

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC1091
 . "$(dirname "$0")/_/husky.sh"
 
 pre-commit run && \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.8.0
+    hooks:
+      - id: shellcheck

--- a/deployment/serve.sh
+++ b/deployment/serve.sh
@@ -3,4 +3,4 @@
 # container only. The script takes any number of gunicorn arguments
 # passed in as a string.
 
-nohup nginx -g "daemon off;" & gunicorn -b 0.0.0.0:5000 -t 600 "explainaboard_web.__main__:create_app()" $1
+nohup nginx -g "daemon off;" & gunicorn -b 0.0.0.0:5000 -t 600 "explainaboard_web.__main__:create_app()" "$1"

--- a/openapi/gen_api_layer.sh
+++ b/openapi/gen_api_layer.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Generates API layer code for backend and frontend based on openapi.yaml
 # reference: https://stackoverflow.com/a/47554626
 
@@ -7,19 +9,19 @@ set -e
 # three modes: generate frontend only, backend only and both
 mode=$1
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
-project_root=`dirname $script_dir`
+project_root=$(dirname "$script_dir")
 
 OPENAPI_PATH="openapi"
 BACKEND_GEN_PATH="backend/src/gen"
 FRONTEND_GEN_PATH="frontend/src/clients/openapi"
 
-if ! [ `which curl` ]; then
+if ! [ "$(which curl)" ]; then
     echo "ERROR: curl not found. Please install curl command."
     exit 1
 fi
 
 # download codegen cli if not exists
-cd $script_dir
+cd "$script_dir"
 if [ ! -f swagger-codegen-cli-3.0.29.jar ]; then
     curl -L -O https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.29/swagger-codegen-cli-3.0.29.jar
 fi
@@ -29,10 +31,10 @@ fi
 if [[ $mode == "backend" || $mode == "project" ]]; then
     # remove src/gen if exists and generate code
     # we also create a link to src/impl in src/gen which contains our own implementation
-    cd $project_root && rm -rf $BACKEND_GEN_PATH && \
+    cd "$project_root" && rm -rf $BACKEND_GEN_PATH && \
     mkdir -p $BACKEND_GEN_PATH/explainaboard_web && \
     cd $BACKEND_GEN_PATH/explainaboard_web/ && \
-    ln -sf ../../impl/ && \
+    ln -sf ../../impl/ . && \
     cd ../../../.. && \
     java -jar $OPENAPI_PATH/swagger-codegen-cli-3.0.29.jar generate \
         -i $OPENAPI_PATH/openapi.yaml \
@@ -49,7 +51,7 @@ fi
 
 # frontend
 if [[ $mode == "frontend" || $mode == "project" ]]; then
-    cd $project_root && rm -rf $FRONTEND_GEN_PATH && \
+    cd "$project_root" && rm -rf $FRONTEND_GEN_PATH && \
     java -jar $OPENAPI_PATH/swagger-codegen-cli-3.0.29.jar generate \
         -i $OPENAPI_PATH/openapi.yaml \
         -l typescript-fetch \


### PR DESCRIPTION
This PR adds a shell script linter, [ShellCheck](https://github.com/koalaman/shellcheck) to pre-commit and CI, and fixes issues found by ShellCheck. I chose ShellCheck because it is recommended by [this shell style guide](https://google.github.io/styleguide/shellguide.html#s6.1-shellcheck). The report is easy to understand, it shows the corresponding wiki page which contains more detailed information related to the error code. As an example, the log of ShellCheck without the fix can be found at [here](https://github.com/neulab/explainaboard_web/actions/runs/3214433532/jobs/5254821570). Note that ShellCheck is licensed under GPLv3.