### PR TITLE
Add a linter to check requirements.txt to pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,14 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: mypy --all-files
+  lint-requirements-txt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: lint
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: requirements-txt-fixer --all-files
   markdownlint:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,4 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: requirements-txt-fixer

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,15 +1,15 @@
 apache-beam~=2.41.0
 boto3~=1.24.68
-pymongo[srv]~=3.12.3
-Flask-PyMongo~=2.3.0
-python-dotenv~=0.21.0
-pyjwt[crypto] ~= 2.3.0
-explainaboard == 0.11.1
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
-pre-commit~=2.20.0
+explainaboard == 0.11.1
+Flask-PyMongo~=2.3.0
+google-cloud-storage~=2.5.0
+iso-639~=0.4.5
 marisa_trie~=0.7.7
+pandas~=1.5.0
+pre-commit~=2.20.0
+pyjwt[crypto] ~= 2.3.0
+pymongo[srv]~=3.12.3
+python-dotenv~=0.21.0
 sacrebleu[ja]~=2.2.1
 six~=1.16.0
-pandas~=1.5.0
-iso-639~=0.4.5
-google-cloud-storage~=2.5.0


### PR DESCRIPTION
This PR adds a linter/formatter, `requirements-txt-fixer` which sorts entries in requirements.txt to pre-commit and CI. Also, fixes the order of entries by applying `requirements-txt-fixer`. With this tool, we don't need to care about ordering of entries any more.