### PR TITLE
Set time limit for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           pip install -r backend/requirements.txt -r backend/src/gen/requirements.txt
       - name: Test
         run: PYTHONPATH=backend/src/gen python -m unittest discover -v backend/src/tests
+        timeout-minutes: 10
   format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR explicitly sets the time limit of 10 minutes for the step to run integration tests so that CI fails if the execution time exceeds the time limit. This is to prevent integration tests from getting slower. The default setting is [360 minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes), which is too long.
