### PR TITLE
Bump mypy version to 0.982

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: upgrade-type-hints
         files: '\.py$'
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.942'
+    rev: 'v0.982'
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
This PR bumps mypy version to 0.982 (the latest version as of writing).