### PR TITLE
Bump flake8 version to 5.0.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         files: '\.py$'
   - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:


### PR DESCRIPTION
This PR bumps flake8 version to 5.0.4 (latest as of writing).