### PR TITLE
Migrate to pyupgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,10 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: flake8 --all-files
-      - name: lint-pep585-compliant
+      - name: lint-upgrade-syntax
         uses: pre-commit/action@v2.0.3
         with:
-          extra_args: upgrade-type-hints --all-files
+          extra_args: pyupgrade --all-files
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     hooks:
       - id: pyupgrade
         files: '\.py$'
+        args: ["--py39-plus"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.982'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,10 @@ repos:
       - id: isort
         files: '\.py$'
         args: ["--profile", "black"]
-  - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: v1.0.1
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.0.0
     hooks:
-      - id: upgrade-type-hints
+      - id: pyupgrade
         files: '\.py$'
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.982'

--- a/backend/src/impl/auth.py
+++ b/backend/src/impl/auth.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import secrets
-from typing import Optional
 
 import boto3
 import jwt
@@ -53,7 +52,7 @@ class User:
     def __init__(
         self,
         is_authenticated: bool,
-        info: Optional[dict] = None,
+        info: dict | None = None,
     ) -> None:
         self._is_authenticated: bool = is_authenticated
         self._info: dict = info.copy() if info else {}

--- a/backend/src/impl/benchmark_utils.py
+++ b/backend/src/impl/benchmark_utils.py
@@ -29,7 +29,7 @@ class BenchmarkUtils:
 
     @staticmethod
     def config_dict_from_file(path_json: str) -> dict:
-        with open(path_json, "r") as fin:
+        with open(path_json) as fin:
             benchmark_config = json.load(fin)
         # If a parent exists, then get the parent and update
         parent_id = benchmark_config.get("parent")
@@ -118,12 +118,10 @@ class BenchmarkUtils:
         # Collect (and deduplicate) all datasets from system infos otherwise
         else:
             dataset_tuples = list(
-                set(
-                    [
-                        (x["dataset_name"], x["sub_dataset_name"], x["dataset_split"])
-                        for x in systems
-                    ]
-                )
+                {
+                    (x["dataset_name"], x["sub_dataset_name"], x["dataset_split"])
+                    for x in systems
+                }
             )
             dataset_configs = [
                 {"dataset_name": x, "sub_dataset": y, "dataset_split": z}
@@ -408,9 +406,7 @@ class BenchmarkUtils:
             json_dict = {k.name: [] for k in config.views}
             json_dict["Original"] = []
             json_dict["times"] = []
-            unique_dates = sorted(
-                list(set([x["created_at"].date() for x in sys_infos]))
-            )
+            unique_dates = sorted(list({x["created_at"].date() for x in sys_infos}))
             for date in unique_dates:
                 systems = [sys for sys in sys_infos if sys["created_at"].date() <= date]
                 orig_df = BenchmarkUtils.generate_dataframe_from_sys_infos(
@@ -423,7 +419,7 @@ class BenchmarkUtils:
                 system_dict = {k: v for k, v in system_dfs}
                 for k, v in system_dfs:
                     if (
-                        (set(system_dict[k].columns) == set(["score", "system_name"]))
+                        (set(system_dict[k].columns) == {"score", "system_name"})
                         and len(json_dict[k]) == 0
                         or (
                             len(json_dict[k]) > 0

--- a/backend/src/impl/db_utils/dataset_db_utils.py
+++ b/backend/src/impl/db_utils/dataset_db_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools
 import json
 from datetime import datetime, timedelta
-from typing import Optional
 
 import marisa_trie
 from explainaboard.utils.cache_api import cache_online_file
@@ -79,7 +78,7 @@ class DatasetDBUtils:
                 lifetime=DatasetDBUtils._cached_lifetime,
             )
             datasets = {}
-            with open(local_path, "r") as fin:
+            with open(local_path) as fin:
                 for line in fin:
                     data = json.loads(line)
                     for k, v in data.items():
@@ -101,10 +100,10 @@ class DatasetDBUtils:
     def find_datasets(
         page: int = 0,
         page_size: int = 0,
-        dataset_ids: Optional[list[str]] = None,
-        dataset_name: Optional[str] = None,
-        sub_dataset: Optional[str] = None,
-        task: Optional[str] = None,
+        dataset_ids: list[str] | None = None,
+        dataset_name: str | None = None,
+        sub_dataset: str | None = None,
+        task: str | None = None,
         no_limit: bool = False,
     ) -> DatasetsReturn:
         my_db = DatasetDBUtils.get_dataset_db()

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -7,7 +7,7 @@ import zlib
 from datetime import datetime
 from inspect import getsource
 from types import FunctionType
-from typing import Any, Optional
+from typing import Any
 
 from bson import ObjectId
 from explainaboard import DatalabLoaderOption, FileType, Source, get_processor
@@ -117,7 +117,7 @@ class SystemDBUtils:
         query: list | dict,
         page: int,
         page_size: int,
-        sort: Optional[list] = None,
+        sort: list | None = None,
         include_datasets: bool = True,
         include_metric_stats: bool = False,
     ):
@@ -180,20 +180,20 @@ class SystemDBUtils:
     def find_systems(
         page: int,
         page_size: int,
-        ids: Optional[list[str]] = None,
-        system_name: Optional[str] = None,
-        task: Optional[str] = None,
-        dataset_name: Optional[str] = None,
-        subdataset_name: Optional[str] = None,
-        split: Optional[str] = None,
-        source_language: Optional[str] = None,
-        target_language: Optional[str] = None,
-        sort: Optional[list] = None,
-        creator: Optional[str] = None,
-        shared_users: Optional[list[str]] = None,
+        ids: list[str] | None = None,
+        system_name: str | None = None,
+        task: str | None = None,
+        dataset_name: str | None = None,
+        subdataset_name: str | None = None,
+        split: str | None = None,
+        source_language: str | None = None,
+        target_language: str | None = None,
+        sort: list | None = None,
+        creator: str | None = None,
+        shared_users: list[str] | None = None,
         include_datasets: bool = True,
         include_metric_stats: bool = False,
-        dataset_list: Optional[list[tuple[str, str, str]]] = None,
+        dataset_list: list[tuple[str, str, str]] | None = None,
     ) -> SystemsReturn:
         """find multiple systems that matches the filters"""
 

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 from functools import lru_cache
-from typing import Optional
 
 import pandas as pd
 from explainaboard import DatalabLoaderOption, TaskType, get_processor
@@ -121,9 +120,9 @@ def datasets_dataset_id_get(dataset_id: str) -> DatasetMetadata:
 
 
 def datasets_get(
-    dataset_ids: Optional[str],
-    dataset_name: Optional[str],
-    task: Optional[str],
+    dataset_ids: str | None,
+    dataset_name: str | None,
+    task: str | None,
     page: int,
     page_size: int,
 ) -> DatasetsReturn:
@@ -140,7 +139,7 @@ def datasets_get(
 """ /benchmarks """
 
 
-def benchmark_configs_get(parent: Optional[str]) -> list[BenchmarkConfig]:
+def benchmark_configs_get(parent: str | None) -> list[BenchmarkConfig]:
     scriptpath = os.path.dirname(__file__)
     config_folder = os.path.join(scriptpath, "./benchmark_configs/")
     # Add benchmarks to here if they should be displayed on the page.
@@ -224,17 +223,17 @@ def systems_get_by_id(system_id: str) -> System:
 
 
 def systems_get(
-    system_name: Optional[str],
-    task: Optional[str],
-    dataset: Optional[str],
-    subdataset: Optional[str],
-    split: Optional[str],
+    system_name: str | None,
+    task: str | None,
+    dataset: str | None,
+    subdataset: str | None,
+    split: str | None,
     page: int,
     page_size: int,
     sort_field: str,
     sort_direction: str,
-    creator: Optional[str],
-    shared_users: Optional[list[str]],
+    creator: str | None,
+    shared_users: list[str] | None,
 ) -> SystemsReturn:
     ids = None
     if not sort_field:

--- a/backend/src/impl/private_dataset.py
+++ b/backend/src/impl/private_dataset.py
@@ -8,9 +8,9 @@ PRIVATE_DATASETS = [
     DatalabLoaderOption("fudan_nlp", "conll2003", "test"),
 ]
 
-_private_dataset_lookup = set(
+_private_dataset_lookup = {
     (dataset.dataset, dataset.subdataset, dataset.split) for dataset in PRIVATE_DATASETS
-)
+}
 
 
 def is_private_dataset(dataset: DatalabLoaderOption):

--- a/backend/src/tests/test_benchmark.py
+++ b/backend/src/tests/test_benchmark.py
@@ -60,7 +60,7 @@ class TestBenchmark(unittest.TestCase):
             exc.__dict__.setdefault("traces", []).append(trace)
             if is_root:
                 trace = " -> ".join(reversed(exc.traces))
-                exc = AssertionError("{}\nTRACE: {}".format(exc.message, trace))
+                exc = AssertionError(f"{exc.message}\nTRACE: {trace}")
             raise exc
 
     def test_masakhaner_aggregate(self):

--- a/backend/src/tests/test_benchmark.py
+++ b/backend/src/tests/test_benchmark.py
@@ -60,7 +60,7 @@ class TestBenchmark(unittest.TestCase):
             exc.__dict__.setdefault("traces", []).append(trace)
             if is_root:
                 trace = " -> ".join(reversed(exc.traces))
-                exc = AssertionError("%s\nTRACE: %s" % (exc.message, trace))
+                exc = AssertionError("{}\nTRACE: {}".format(exc.message, trace))
             raise exc
 
     def test_masakhaner_aggregate(self):

--- a/backend/src/tests/test_get_tasks.py
+++ b/backend/src/tests/test_get_tasks.py
@@ -23,7 +23,7 @@ class TestTasks(unittest.TestCase):
                 supported_formats = get_loader_class(task.name).supported_file_types()
                 self.assertEqual(
                     len(supported_metrics),
-                    len(set([x.name for x in supported_metrics])),
+                    len({x.name for x in supported_metrics}),
                     f"duplicate metric names in {task.name}",
                 )
                 self.assertGreater(len(supported_formats.custom_dataset), 0)


### PR DESCRIPTION
This PR migrates [pep585-upgrade](https://github.com/snok/pep585-upgrade) to [pyupgrade](https://github.com/asottile/pyupgrade) because pep585-upgrade is now archived. It recommends using pyupgrade instead.  pyupgrade allows automatic update syntax for new versions of Python. This PR actually updates code by running `pre-commit run pyupgrade --all-files`. Note that this replaces `typing.Optional` with `T | None` ([PEP 604](https://peps.python.org/pep-0604)). This rewrite is safe because the changed files import `from __future__ import annotations`. 