### PR TITLE
Add python- prefix to Python related CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Test
         run: PYTHONPATH=backend/src/gen python -m unittest discover -v backend/src/tests
         timeout-minutes: 10
-  format:
+  python-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: black --all-files
-  isort:
+  python-isort:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: isort --all-files
-  lint:
+  python-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -100,7 +100,7 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: pyupgrade --all-files
-  typecheck:
+  python-typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds "python-" prefix to the Python related CI jobs. This is to make the scope of the jobs clear, given that this repository is a multi-language repository. For example, currently, it's not clear which code is checked by the `format`, `lint`, and `typecheck` jobs without looking at `.github/workflows/ci.yml`. This is a preliminary change for adding CI jobs for frontend.