### PR TITLE
Add prettier to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,25 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: mypy --all-files
+  frontend-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: 'frontend/.nvmrc'
+      - name: Cache Node modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/node_modules
+          key: node-${{ hashFiles('.nvmrc', 'frontend/package-lock.json') }}
+      - name: Install Node dependencies
+        run: npm install
+        working-directory: frontend
+      - name: format
+        run: npm run prettier-check
+        working-directory: frontend
   lint-requirements-txt:
     runs-on: ubuntu-latest
     steps:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "react-scripts start",
     "prettier": "prettier --write --ignore-unknown .",
+    "prettier-check": "prettier --check --ignore-unknown .",
     "lint": "eslint --ext .js,.ts,.tsx,.js .",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
Part of #415. This is the initial PR to add linter/formatter for frontend to CI. pre-commit hooks for frontend are well configured, but it's possible for users to bypass the hooks. As a safeguard for the case, it's better to set up CI for frontend as well.

This PR adds `prettier` to CI, and a script to run prettier with the [--check](https://prettier.io/docs/en/cli.html#--check) option for CI.