### PR TITLE
Rename CI jobs to lint Markdown and YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: requirements-txt-fixer --all-files
-  markdownlint:
+  lint-markdown:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -132,7 +132,7 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: markdownlint-cli2 --all-files
-  yamllint:
+  lint-yaml:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR renames CI jobs that lint Markdown and YAML. This is to organize the order of CI jobs in UI.