### PR TITLE
Add type-check for TypeScript code to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
         with:
           path: frontend/node_modules
           key: node-${{ hashFiles('.nvmrc', 'frontend/package-lock.json') }}
+      - name: Generate client code from OpenAPI definition
+        run: npm run gen-api-code
       - name: Install Node dependencies
         run: npm install
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,25 @@ jobs:
         uses: pre-commit/action@v2.0.3
         with:
           extra_args: mypy --all-files
+  frontend-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: 'frontend/.nvmrc'
+      - name: Cache Node modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/node_modules
+          key: node-${{ hashFiles('.nvmrc', 'frontend/package-lock.json') }}
+      - name: Install Node dependencies
+        run: npm install
+        working-directory: frontend
+      - name: typecheck
+        run: npm run typecheck
+        working-directory: frontend
   lint-requirements-txt:
     runs-on: ubuntu-latest
     steps:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,13 +6,8 @@
     "start": "react-scripts start",
     "prettier": "prettier --write --ignore-unknown .",
     "prettier-check": "prettier --check --ignore-unknown .",
-<<<<<<< HEAD
-    "lint": "eslint --ext .js,.ts,.tsx,.js .",
-    "typecheck": "tsc",
-=======
     "lint": "eslint --max-warnings 0 --ext .js,.ts,.tsx,.js .",
     "typecheck": "tsc",
->>>>>>> main
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "start": "react-scripts start",
     "prettier": "prettier --write --ignore-unknown .",
     "lint": "eslint --ext .js,.ts,.tsx,.js .",
+    "typecheck": "tsc",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,5 +17,6 @@
     "strict": true,
     "strictPropertyInitialization": false
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Part of #415. This PR adds a CI job to run `tsc` to type-check TypeScript code. Updates `tsconfig.json` so that the type-checker ignores auto-generated code `*.spec.ts` by swagger-codegen such as `frontend/src/clients/openapi/api_test.spec.ts` because the type annotation generated by the code is not correct and basically out of our control.