### PR TITLE
Force ESLint to exit with an error status if any warning is found

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "react-scripts start",
     "prettier": "prettier --write --ignore-unknown .",
-    "lint": "eslint --ext .js,.ts,.tsx,.js .",
+    "lint": "eslint --max-warnings 0 --ext .js,.ts,.tsx,.js .",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -37,8 +37,13 @@
   },
   "lint-staged": {
     "**/*": [
-      "npm run lint",
       "npm run prettier"
+    ],
+    "**/*.ts": [
+      "npm run lint"
+    ],
+    "**/*.tsx": [
+      "npm run lint"
     ]
   },
   "browserslist": {

--- a/frontend/src/components/Analysis/types.tsx
+++ b/frontend/src/components/Analysis/types.tsx
@@ -1,6 +1,6 @@
 // interface modified from https://app.quicktype.io/
 
-import { AnalysisCase, Performance, ComboCount } from "../../clients/openapi";
+import { Performance, ComboCount } from "../../clients/openapi";
 
 export interface ResultFineGrainedParsed {
   /**


### PR DESCRIPTION
Part of #415. Currently, ESLint via `npm run lint` exits with zero status code even if there is a warning in the project (Every warning reported by the linter needs to be fixed. Otherwise, non-actionable warnings must be turned off completely to keep automation working). This behavior is expected according to the default value of the [--max-warnings option](https://eslint.org/docs/latest/user-guide/command-line-interface#--max-warnings). This behavior accidentally could sneak code changes with warnings into `main` because we use CI as an alert for that changes, meaning that we expect any linter to exit with non-zero exit status code when there is an issue in a code change so that CI system can block merging that change.

This PR addresses the issue above. Here is a list of the changes:
* Updates the configuration of `npm run lint` so that eslint exits with non-zero exit status when there is a warning.
* Run `npm run lint` only when `.ts` and `.tsx` files are updated. This is to avoid errors in `lint-stage`: `lint-stage` fails when we stage the files to be ignored in `frontend/.eslintignore` because those files are passed to `npm run lint`, which cause ESLint to warn that ignored files are passed, but `npm run lint` is configured to exit with an error if there is warning.
* Fixes the previously known warning in `frontend/src/components/Analysis/types.tsx`: `AnalysisCase` is imported but unused.