### PR TITLE
Check Python code conforms to PEP 8 naming conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
         additional_dependencies:
           - flake8-absolute-import
           - flake8-black>=0.1.1
+          - pep8-naming
         entry: flake8
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git

--- a/backend/src/impl/auth.py
+++ b/backend/src/impl/auth.py
@@ -8,7 +8,7 @@ from explainaboard_web.impl.utils import abort_with_error_message
 from flask import current_app, g
 
 
-def check_ApiKeyAuth(user_email: str, api_key: str, required_scopes):
+def check_api_key_auth(user_email: str, api_key: str, required_scopes):
     """
     :param user_id: we use user email as ID
     :param api_key: is generated for the user when they login for the first time. Only
@@ -24,7 +24,7 @@ def check_ApiKeyAuth(user_email: str, api_key: str, required_scopes):
     return {}
 
 
-def check_BearerAuth(token: str):
+def check_bearer_auth(token: str):
     """JWT authentication"""
     public_key_url = f"https://cognito-idp.{current_app.config.get('AWS_DEFAULT_REGION')}.amazonaws.com/{current_app.config.get('USER_POOL_ID')}/.well-known/jwks.json"  # noqa
     public_key = jwt.PyJWKClient(public_key_url).get_signing_key_from_jwt(token)

--- a/backend/src/impl/auth.py
+++ b/backend/src/impl/auth.py
@@ -8,7 +8,8 @@ from explainaboard_web.impl.utils import abort_with_error_message
 from flask import current_app, g
 
 
-def check_api_key_auth(user_email: str, api_key: str, required_scopes):
+# Disables N802 to follow the naming scheme in the OpenAPI definition.
+def check_ApiKeyAuth(user_email: str, api_key: str, required_scopes):  # noqa: N802
     """
     :param user_id: we use user email as ID
     :param api_key: is generated for the user when they login for the first time. Only
@@ -24,7 +25,8 @@ def check_api_key_auth(user_email: str, api_key: str, required_scopes):
     return {}
 
 
-def check_bearer_auth(token: str):
+# Disables N802 to follow the naming scheme in the OpenAPI definition.
+def check_BearerAuth(token: str):  # noqa: N802
     """JWT authentication"""
     public_key_url = f"https://cognito-idp.{current_app.config.get('AWS_DEFAULT_REGION')}.amazonaws.com/{current_app.config.get('USER_POOL_ID')}/.well-known/jwks.json"  # noqa
     public_key = jwt.PyJWKClient(public_key_url).get_signing_key_from_jwt(token)

--- a/backend/src/impl/init.py
+++ b/backend/src/impl/init.py
@@ -15,10 +15,10 @@ def init(app: Flask) -> Flask:
 
 
 def _init_config(app: Flask):
-    FLASK_ENV = os.getenv("FLASK_ENV")
-    if FLASK_ENV == "production":
+    flask_env = os.getenv("FLASK_ENV")
+    if flask_env == "production":
         app.config.from_object(ProductionConfig())
-    elif FLASK_ENV == "development":
+    elif flask_env == "development":
         app.config.from_object(LocalDevelopmentConfig())
-    elif FLASK_ENV == "staging":
+    elif flask_env == "staging":
         app.config.from_object(StagingConfig())

--- a/backend/src/tests/test_benchmark.py
+++ b/backend/src/tests/test_benchmark.py
@@ -22,7 +22,7 @@ class TestBenchmark(unittest.TestCase):
             "benchmark_configs",
         )
 
-    def assertDeepAlmostEqual(self, expected, actual, *args, **kwargs):
+    def assertDeepAlmostEqual(self, expected, actual, *args, **kwargs):  # noqa: N802
         """
         Assert that two complex structures have almost equal contents.
 


### PR DESCRIPTION
This PR adds a flake8 plugin, [pep8-naming](https://github.com/PyCQA/pep8-naming) to automatically check whether Python code conforms to PEP 8 naming conventions. This also fixes the code that doesn't follow the naming conventions except the custom assertion, `assertDeepAlmostEqual` in `backend/src/tests/test_benchmark.py` and the functions in `backend/src/impl/auth.py`.