### PR TITLE
Bump black version to 22.10.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black.git
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         files: '\.py$'


### PR DESCRIPTION
This PR bumps black version to 22.10.0 (latest as of writing) so that it includes bug fixes and improvements such as psf/black#3035 (the fix is a part of the [preview style](https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#preview-style) we need a discuss separately).