### PR TITLE
display custom analysis

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -284,6 +284,7 @@ class SystemDBUtils:
         metadata: SystemMetadata,
         system_output_data: FileLoaderReturn,
         custom_features: dict,
+        custom_analyses: dict,
     ):
         processor = get_processor(metadata.task)
         metrics_lookup = {
@@ -305,6 +306,7 @@ class SystemDBUtils:
             "task_name": metadata.task,
             "metric_configs": metric_configs,
             "custom_features": custom_features,
+            "custom_analyses": custom_analyses,
         }
 
         return processor.get_overall_statistics(
@@ -403,6 +405,7 @@ class SystemDBUtils:
             system_custom_features: dict = (
                 system_output_data.metadata.custom_features or {}
             )
+            custom_analyses: dict = system_output_data.metadata.custom_analyses or {}
 
             # -- combine custom features from the two sources
             custom_features = dict(system_custom_features)
@@ -410,7 +413,7 @@ class SystemDBUtils:
 
             # -- do the actual analysis and binarize the metric stats
             overall_statistics = SystemDBUtils._process(
-                system, metadata, system_output_data, custom_features
+                system, metadata, system_output_data, custom_features, custom_analyses
             )
             binarized_stats = [
                 [binarize_bson(y.get_data()) for y in x]

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -188,26 +188,31 @@ export function parseFineGrainedResults(
       analysisIdx++
     ) {
       const myResult = singleAnalysis.analysis_results[analysisIdx];
-      const myAnalysis: Analysis = system.system_info.analyses.filter(
+      const analysisFeature =
+        myResult.cls_name === "BucketAnalysisResult"
+          ? myResult.name
+          : myResult.features.sort().join();
+      // Find the analysis setting for the system analysis
+      // Analysis results may not be in the same order or size as analysis settings
+      const myAnalysis: Analysis | undefined = system.system_info.analyses.find(
         (analysis) => {
           if (myResult.cls_name === "BucketAnalysisResult") {
             return (
               analysis.cls_name === "BucketAnalysis" &&
-              analysis.feature === myResult.name
+              analysis.feature === analysisFeature
             );
           } else {
             return (
               analysis.cls_name === "ComboCountAnalysis" &&
-              myResult.features.sort().join() ===
-                analysis.features.sort().join()
+              analysis.features.sort().join() === analysisFeature
             );
           }
         }
-      )[0];
+      );
 
       const analysisName = myResult.name;
-      const analysisDescription = myAnalysis.description;
-      const bucketType = myAnalysis["method"];
+      const analysisDescription = myAnalysis?.description;
+      const bucketType = myAnalysis ? myAnalysis["method"] : "";
 
       if (myResult.cls_name === "BucketAnalysisResult") {
         const metricToParsed = parseBucketAnalysisFeatures(

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -4,6 +4,7 @@ import {
   SingleAnalysis,
   AnalysisResult,
   Performance,
+  Analysis,
 } from "../../clients/openapi";
 import { SystemModel } from "../../models";
 
@@ -186,8 +187,23 @@ export function parseFineGrainedResults(
       analysisIdx < singleAnalysis.analysis_results.length;
       analysisIdx++
     ) {
-      const myAnalysis = system.system_info.analyses[analysisIdx];
       const myResult = singleAnalysis.analysis_results[analysisIdx];
+      const myAnalysis: Analysis = system.system_info.analyses.filter(
+        (analysis) => {
+          if (myResult.cls_name === "BucketAnalysisResult") {
+            return (
+              analysis.cls_name === "BucketAnalysis" &&
+              analysis.feature === myResult.name
+            );
+          } else {
+            return (
+              analysis.cls_name === "ComboCountAnalysis" &&
+              myResult.features.sort().join() ===
+                analysis.features.sort().join()
+            );
+          }
+        }
+      )[0];
 
       const analysisName = myResult.name;
       const analysisDescription = myAnalysis.description;


### PR DESCRIPTION
## Display custom analysis on the web
This PR is related to issue #325.

* Backend: in the previous code, only custom features are saved in the database. In this PR, save custom analysis in the output file in the database as well.
* Frontend: since the returned analysis results skip failed analysis, there is a number and order mismatch between system analysis list and analysis result list. In the PR, find the correct analysis setting for each analysis result. 

The custom analysis defined in the system output file (verb, subject, adverb, LL_delta) can be displayed now. The title of each graph is `${metric} by ${analysisDescription}`.

![Screen Shot 2022-10-12 at 1 32 44 AM](https://user-images.githubusercontent.com/71625258/195259348-341f5835-64b6-473a-b696-e8af78121a6b.png)
