### PR TITLE
Remove double ampersand from gen_api_layer.sh

### DIFF
--- a/openapi/gen_api_layer.sh
+++ b/openapi/gen_api_layer.sh
@@ -31,11 +31,12 @@ fi
 if [[ $mode == "backend" || $mode == "project" ]]; then
     # remove src/gen if exists and generate code
     # we also create a link to src/impl in src/gen which contains our own implementation
-    cd "$project_root" && rm -rf $BACKEND_GEN_PATH && \
-    mkdir -p $BACKEND_GEN_PATH/explainaboard_web && \
-    cd $BACKEND_GEN_PATH/explainaboard_web/ && \
-    ln -sf ../../impl/ . && \
-    cd ../../../.. && \
+    cd "$project_root"
+    rm -rf $BACKEND_GEN_PATH
+    mkdir -p $BACKEND_GEN_PATH/explainaboard_web
+    cd $BACKEND_GEN_PATH/explainaboard_web/
+    ln -sf ../../impl/ .
+    cd ../../../..
     java -jar $OPENAPI_PATH/swagger-codegen-cli-3.0.29.jar generate \
         -i $OPENAPI_PATH/openapi.yaml \
         -l python-flask \
@@ -44,20 +45,21 @@ if [[ $mode == "backend" || $mode == "project" ]]; then
         -c $OPENAPI_PATH/swagger-codegen-config.json
 
     # Couldn't find a way to omit these default files from the templates so manully remove them
-    cd $BACKEND_GEN_PATH && \
+    cd $BACKEND_GEN_PATH
     rm Dockerfile .gitignore .travis.yml git_push.sh tox.ini test-requirements.txt .dockerignore setup.py
 fi
 
 
 # frontend
 if [[ $mode == "frontend" || $mode == "project" ]]; then
-    cd "$project_root" && rm -rf $FRONTEND_GEN_PATH && \
+    cd "$project_root"
+    rm -rf $FRONTEND_GEN_PATH
     java -jar $OPENAPI_PATH/swagger-codegen-cli-3.0.29.jar generate \
         -i $OPENAPI_PATH/openapi.yaml \
         -l typescript-fetch \
         -o $FRONTEND_GEN_PATH \
         -t $OPENAPI_PATH/ts_templates \
         -c $OPENAPI_PATH/swagger-codegen-config.json
-    cd $FRONTEND_GEN_PATH && \
+    cd $FRONTEND_GEN_PATH
     rm git_push.sh .gitignore
 fi


### PR DESCRIPTION
This PR removes double ampersand from `openapi/gen_api_layer.sh`. The double ampersand is not necessary because the shell script uses `set -e` before running commands. (See the [manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#index-set) of `set -e` for details).