### PR TITLE
Bump pre-commit/action version to v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           python-version: 3.9
       - name: format
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: black --all-files
   python-isort:
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.9
       - name: isort
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: isort --all-files
   python-lint:
@@ -93,11 +93,11 @@ jobs:
         with:
           python-version: 3.9
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: flake8 --all-files
       - name: lint-upgrade-syntax
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: pyupgrade --all-files
   python-typecheck:
@@ -109,7 +109,7 @@ jobs:
         with:
           python-version: 3.9
       - name: mypy
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: mypy --all-files
   frontend-format:
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: requirements-txt-fixer --all-files
   lint-markdown:
@@ -188,7 +188,7 @@ jobs:
         with:
           node-version: 18.x
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: markdownlint-cli2 --all-files
   lint-yaml:
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: yamllint --all-files
   lint-dockerfile:
@@ -212,7 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: trailing-whitespace --all-files
   lint-eof-newline:
@@ -220,7 +220,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: end-of-file-fixer --all-files
   lint-shell-script:
@@ -228,6 +228,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: shellcheck --all-files


### PR DESCRIPTION
This bumps pre-commit/action version to v3.0.0. 

Currently, we see the following warnings in our workflows:

<img width="1892" alt="Screen Shot 2022-10-18 at 2 01 47" src="https://user-images.githubusercontent.com/1183444/196238884-bd8d9b0d-b4de-4ae6-90eb-bba4131bcd6a.png">

10 warnings out of the total 16 warnings are caused by the following reasons:
* GitHub started to add a warning if a workflow has Actions that run Node 12 since September 22 (See [blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for details).
* `pre-commit/action@v2.0.3` [uses Node 12](https://github.com/pre-commit/action/blob/v2.0.3/action.yml#L12).

These warnings can be removed by updating pre-commit/action to v3.0.0 because v3.0.0 [doesn't depend on Node anymore](https://github.com/pre-commit/action/blob/v3.0.0/action.yml).

The remaining warnings will be fixed in follow up PRs.