### PR TITLE
Bump actions/setup-node version to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.9
           cache: 'pip'
       - name: Install node 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
       - name: Cache node modules
@@ -48,7 +48,7 @@ jobs:
           python-version: 3.9
           cache: 'pip'
       - name: Install node 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
       - name: Generate code
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install node 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
       - name: Cache Node modules
@@ -136,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install node 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
       - name: Cache Node modules
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install node 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'frontend/.nvmrc'
       - name: Cache Node modules


### PR DESCRIPTION
This PR bumps actions/setup-node version to v3 in order to remaining warnings as mentioned in https://github.com/neulab/explainaboard_web/pull/429.