### PR TITLE
db_schema: system_info.system_name -> system_name

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -232,9 +232,7 @@ class SystemDBUtils:
         if ids:
             search_conditions.append({"_id": {"$in": [ObjectId(_id) for _id in ids]}})
         if system_name:
-            search_conditions.append(
-                {"system_info.system_name": {"$regex": rf"^{system_name}.*"}}
-            )
+            search_conditions.append({"system_name": {"$regex": rf"^{system_name}.*"}})
         if task:
             search_conditions.append({"system_info.task_name": task})
         if dataset_name:
@@ -519,7 +517,7 @@ class SystemDBUtils:
 
         # TODO a more general, flexible solution instead of hard coding
         field_to_value = {
-            "system_info.system_name": metadata.system_name,
+            "system_name": metadata.system_name,
             "is_private": metadata.is_private,
             "shared_users": metadata.shared_users,
             "system_details": metadata.system_details,

--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -198,11 +198,9 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
 
   function getDrawerTitle(): string {
     if (systems.length === 1) {
-      return `Single Analysis of ${systems[0].system_info.system_name}`;
+      return `Single Analysis of ${systems[0].system_name}`;
     } else if (systems.length === 2) {
-      const systemNames = systems
-        .map((sys) => sys.system_info.system_name)
-        .join(" and ");
+      const systemNames = systems.map((sys) => sys.system_name).join(" and ");
       return `Pairwise Analysis of ${systemNames}`;
     }
     return "Analysis";

--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -34,7 +34,7 @@ export function ExampleTable({
     [systems]
   );
   const systemNames = useMemo(
-    () => systems.map((system) => system.system_info.system_name),
+    () => systems.map((system) => system.system_name),
     [systems]
   );
   const systemIDsArray = useMemo(
@@ -69,13 +69,10 @@ export function ExampleTable({
         >
           {systems.map((system, sysIndex) => {
             return (
-              <Tabs.TabPane
-                tab={system.system_info.system_name}
-                key={`${sysIndex}`}
-              >
+              <Tabs.TabPane tab={system.system_name} key={`${sysIndex}`}>
                 <AnalysisTable
                   systemIDs={systemIDsArray[sysIndex]}
-                  systemNames={[system.system_info.system_name]}
+                  systemNames={[system.system_name]}
                   task={task}
                   cases={cases[sysIndex]}
                   changeState={changeState}

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -30,7 +30,7 @@ export function FineGrainedBarChart(props: Props) {
     onBarClick,
   } = props;
   // For invariant variables across all systems, we can simply take from the first result
-  const systemNames = systems.map((system) => system.system_info.system_name);
+  const systemNames = systems.map((system) => system.system_name);
   const resultFirst = results[0];
   const bucketNames = resultFirst.bucketNames;
   const featureName = resultFirst.featureName;

--- a/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
@@ -16,7 +16,7 @@ export function OverallMetricsBarChart({
   metricNames,
   onBarClick,
 }: Props) {
-  const systemNames = systems.map((system) => system.system_info.system_name);
+  const systemNames = systems.map((system) => system.system_name);
   const resultsValues: number[][] = [];
   const resultsNumbersOfSamples: number[][] = [];
   const resultsConfidenceScores: Array<[number, number]>[] = [];

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -388,7 +388,7 @@ export function SystemSubmitDrawer(props: Props) {
           initialValues={
             editMode
               ? {
-                  name: systemToEdit?.system_info.system_name,
+                  name: systemToEdit?.system_name,
                   // Must be boolean
                   is_private: systemToEdit?.is_private || false,
                   shared_users: systemToEdit?.shared_users,

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -82,12 +82,12 @@ export function SystemTableContent({
       align: "center",
     },
     {
-      dataIndex: ["system_info", "system_name"],
+      dataIndex: "system_name",
       fixed: "left",
       title: "Name",
       render: (_, record) => (
         <div>
-          <Text strong>{record.system_info.system_name}</Text>
+          <Text strong>{record.system_name}</Text>
           {record.is_private && (
             <span style={{ paddingLeft: "3px" }}>
               <PrivateIcon />

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -953,6 +953,8 @@ components:
         - properties:
             system_id:
               type: string
+            system_name:
+              type: string
             is_private:
               type: boolean
             system_info:
@@ -998,6 +1000,7 @@ components:
           required:
             [
               system_id,
+              system_name,
               is_private,
               system_info,
               metric_stats,


### PR DESCRIPTION
part of #433 - Step 1: Move fields out of System.system_info

- This PR moves `system_info.system_name` -> `system_name`. I won't delete `system_info.system_name` from the DB just yet though. I only removed the code that depends on it.
- DB migration is required. I plan to run the migration on the original collection because the operation is simple. This is tested on dev. I will run the migration script on the production DB when this PR is merged.