### PR TITLE
fix fine grained analysis bar chart order

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -241,13 +241,18 @@ class SystemDBUtils:
             ]
             search_conditions.append({"$or": dataset_dicts})
 
-        return SystemDBUtils.query_systems(
+        systems_return = SystemDBUtils.query_systems(
             search_conditions,
             page,
             page_size,
             sort,
             include_metric_stats,
         )
+        if ids and not sort:
+            # preserve id order if no `sort` is provided
+            orders = {sys_id: i for i, sys_id in enumerate(ids)}
+            systems_return.systems.sort(key=lambda sys: orders[sys.system_id])
+        return systems_return
 
     @staticmethod
     def _load_sys_output(

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -267,7 +267,6 @@ def systems_get(
     creator: str | None,
     shared_users: list[str] | None,
 ) -> SystemsReturn:
-    ids = None
     if not sort_field:
         sort_field = "created_at"
     if not sort_direction:
@@ -282,7 +281,6 @@ def systems_get(
     return SystemDBUtils.find_systems(
         page=page,
         page_size=page_size,
-        ids=ids,
         system_name=system_name,
         task=task,
         dataset_name=dataset,
@@ -397,28 +395,12 @@ def systems_analyses_post(body: SystemsAnalysesBody):
 
     system_analyses: list[SingleAnalysis] = []
     system_ids: list = system_ids_str.split(",")
-    system_name = None
-    task = None
-    dataset_name = None
-    subdataset_name = None
-    split = None
-    creator = None
-    shared_users = None
     page = 0
     page_size = len(system_ids)
-    sort = None
     systems: list[System] = SystemDBUtils.find_systems(
         ids=system_ids,
         page=page,
         page_size=page_size,
-        task=task,
-        system_name=system_name,
-        dataset_name=dataset_name,
-        subdataset_name=subdataset_name,
-        split=split,
-        sort=sort,
-        creator=creator,
-        shared_users=shared_users,
         include_metric_stats=True,
     ).systems
     systems_len = len(systems)


### PR DESCRIPTION
fixes #443 
- `find_systems()` now preserves the order of the `ids` if no `sort` is specified. This is required because **POST /systems/analyese** expects the analyses to be returned in the same order as the `system_ids`. A more robust design would return a dictionary so there is a clear mapping between the `system_id` and the analysis reports in the response body. We can maybe fix this in the future.
- `systems_analyses_post()` only uses a subset of the filters provided by `find_systems()` but passes `None` to the rest of the filters. This makes it unclear which filters are actually being used. This PR removes these arguments so it would just use the default values defined in `find_systems()`.