### PR TITLE
Use cases instead of API call to get systemOutputs

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -55,7 +55,7 @@ export function ExampleTable({
         systemIDs={systemIDs}
         systemNames={systemNames}
         task={task}
-        cases={cases[0]}
+        casesList={cases}
         changeState={changeState}
       />
     );
@@ -74,7 +74,7 @@ export function ExampleTable({
                   systemIDs={systemIDsArray[sysIndex]}
                   systemNames={[system.system_name]}
                   task={task}
-                  cases={cases[sysIndex]}
+                  casesList={[cases[sysIndex]]}
                   changeState={changeState}
                 />
               </Tabs.TabPane>

--- a/frontend/src/components/Analysis/AnalysisTable/utils.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/utils.tsx
@@ -1,4 +1,4 @@
-import { SystemOutput } from "../../../clients/openapi";
+import { AnalysisCase, SystemOutput } from "../../../clients/openapi";
 import { taskColumnMapping, ColumnInfo } from "./taskColumnMapping";
 
 export function addPredictionColInfo(
@@ -82,4 +82,33 @@ export function joinResults(
     row[prop] = predictions;
   }
   return joinedResult;
+}
+
+/**
+ * Converts a list of AnalysisCase to a list of SystemOutput by unnesting
+ * the `features` in AnalysisCase and using `id` instead of `sample_id`.
+ */
+export function convertCasesToSystemOutput(
+  cases: AnalysisCase[]
+): SystemOutput[] {
+  const res: SystemOutput[] = [];
+  for (let i = 0; i < cases.length; i++) {
+    const currOutput: SystemOutput = {};
+    const currCase = cases[i];
+    for (const [key, value] of Object.entries(currCase)) {
+      if (typeof value === "object") {
+        for (const [k, v] of Object.entries(value)) {
+          currOutput[k] = v;
+        }
+      } else {
+        if (key === "sample_id") {
+          currOutput["id"] = value;
+        } else {
+          currOutput[key] = value;
+        }
+      }
+    }
+    res.push(currOutput);
+  }
+  return res;
 }


### PR DESCRIPTION
### Background
Previously in AnalysisTable, we called the API `backendClient.systemOutputsGetById()` to collect systemOutputs. And we used these to display the examples in our ExampleTable.
However, the examples we need _already exist_ in the `cases` argument which are passed in while creating the `AnalysisTable` component, so the use of API can actually be removed. On top of that, the examples we show in the table should be derived from the cases in each bucket instead of the systemOutputs.

### Changes
In this PR, I added a function `convertCasesToSystemOutput()` in `.../AnalysisTable/utils.tsx` which converts the cases format to systemOutput format. By using this function, we can replace the need to call the API.

### Next steps
It also seems that all variables using the struct `SystemOutput` used in AnalysisTable could be changed to `AnalysisCase` after this PR. Since there are quite a few functions using `SystemOutput` structs, I will make these changes in a different PR.
