### PR TITLE
Bugfix: display correct sentences for Sequence Labeling Tasks in AnalysisTable

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -55,7 +55,7 @@ export function ExampleTable({
         systemIDs={systemIDs}
         systemNames={systemNames}
         task={task}
-        cases={cases[0]}
+        casesList={cases}
         changeState={changeState}
       />
     );
@@ -74,7 +74,7 @@ export function ExampleTable({
                   systemIDs={systemIDsArray[sysIndex]}
                   systemNames={[system.system_name]}
                   task={task}
-                  cases={cases[sysIndex]}
+                  casesList={[cases[sysIndex]]}
                   changeState={changeState}
                 />
               </Tabs.TabPane>

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -181,6 +181,7 @@ export function AnalysisTable({
   const cases = casesList[0];
   const [page, setPage] = useState(0);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
+  const [casesThisPage, setCasesThisPage] = useState<AnalysisCase[]>([]);
   const pageSize = 10;
   const total = cases.length;
   const tableRef = useRef<null | HTMLDivElement>(null);
@@ -195,7 +196,8 @@ export function AnalysisTable({
       try {
         const offset = page * pageSize;
         const end = Math.min(offset + pageSize, cases.length);
-        const outputIDs = cases.slice(offset, end).map((x) => x.sample_id);
+        const casesThisPage = cases.slice(offset, end);
+        const outputIDs = casesThisPage.map((x) => x.sample_id);
         let joinedResult: SystemOutput[] = [];
         const results = [];
         for (const systemID of systemIDs) {
@@ -216,6 +218,7 @@ export function AnalysisTable({
         }
 
         setSystemOutputs(joinedResult);
+        setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {
@@ -258,7 +261,7 @@ export function AnalysisTable({
   const numSystems = systemIDs.length;
   const taskCols = taskColumnMapping.get(task);
   if (seqLabTasks.includes(task)) {
-    dataSource = specifyDataSeqLab(systemOutputs, cases, columns);
+    dataSource = specifyDataSeqLab(systemOutputs, casesThisPage, columns);
   } else if (taskCols !== undefined) {
     colInfo = addPredictionColInfo(task, systemNames);
     /* expand columns if it is multi-system analysis */

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   systemIDs: string[];
   systemNames: string[];
   task: string;
-  cases: AnalysisCase[];
+  casesList: AnalysisCase[][];
   changeState: (newState: PageState) => void;
 }
 
@@ -174,9 +174,11 @@ export function AnalysisTable({
   systemIDs,
   systemNames,
   task,
-  cases,
+  casesList,
   changeState,
 }: Props) {
+  // the cases for each system are the same except for predicted_label
+  const cases = casesList[0];
   const [page, setPage] = useState(0);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
   const pageSize = 10;


### PR DESCRIPTION
### Previous Error
The sentences shown in pages after 2 were incorrect, as shown in image (easiest way to check: span text can not be found in sentence). They were always choosing the first 10 cases despite the page chosen.

<img width="796" alt="截圖 2022-10-24 下午5 01 53" src="https://user-images.githubusercontent.com/36850051/197629209-dd009c7e-2626-4bf7-af7a-5b3dd4099dc3.png">
This is because the cases passed in were not limited to the current viewing page. This PR fixes this problem.