### PR TITLE
fixed combo analysis title and value calculation

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -70,7 +70,15 @@ export function ComboAnalysisChart(props: Props) {
     }
   }
 
+  // Total samples for each true label
   const entryDataSum: { [category: number]: number } = {};
+
+  /**
+   * `entryData` and `entryRatioData` are arrays of entries (arrays of length 3)
+   * each entry is [<true_label>, <predicted_label>, <value>]
+   * where <value> is sample count (integer) in `entryData`
+   * and ratio (float) in `entryRatioData`, respectively
+   */
   entryData.forEach((entry) => {
     const trueLabel = entry[0];
     entryDataSum[trueLabel] = (entryDataSum[trueLabel] || 0) + entry[2];

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -54,8 +54,7 @@ export function ComboAnalysisChart(props: Props) {
   for (const count of counts) {
     // count.bucket is a string array of bucket values
     // e.g., [true, false] (true label, predicted label)
-    const featA: string = count.bucket[0];
-    const featB: string = count.bucket[1];
+    const [featA, featB] = count.bucket;
     // count.count is the number of samples
     const nSamples = count.count;
     entryData.push([
@@ -80,14 +79,18 @@ export function ComboAnalysisChart(props: Props) {
    * and ratio (float) in `entryRatioData`, respectively
    */
   entryData.forEach((entry) => {
-    const trueLabel = entry[0];
-    entryDataSum[trueLabel] = (entryDataSum[trueLabel] || 0) + entry[2];
+    const [trueLabel, , count] = entry;
+    entryDataSum[trueLabel] = (entryDataSum[trueLabel] || 0) + count;
   });
-  const entryRatioData = entryData.map((entry) => [
-    entry[0],
-    entry[1],
-    +(entry[2] / entryDataSum[entry[0]]).toFixed(3),
-  ]);
+  const entryRatioData = entryData.map((entry) => {
+    const [trueLabel, predictedLabel, count] = entry;
+
+    return [
+      trueLabel,
+      predictedLabel,
+      +(count / entryDataSum[trueLabel]).toFixed(3),
+    ];
+  });
 
   // Get array min and max
   let min = Infinity;
@@ -96,8 +99,8 @@ export function ComboAnalysisChart(props: Props) {
   let maxRatio = 0;
 
   for (let i = 0; i < entryData.length; i++) {
-    const nSamples = entryData[i][2];
-    const ratio = entryRatioData[i][2];
+    const [, , nSamples] = entryData[i];
+    const [, , ratio] = entryRatioData[i];
     min = Math.min(min, nSamples);
     max = Math.max(max, nSamples);
     minRatio = Math.min(minRatio, ratio);

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -70,12 +70,15 @@ export function ComboAnalysisChart(props: Props) {
     }
   }
 
-  let entryDataSum = 0;
-  entryData.forEach((entry) => (entryDataSum += entry[2]));
+  const entryDataSum: { [category: number]: number } = {};
+  entryData.forEach((entry) => {
+    const trueLabel = entry[0];
+    entryDataSum[trueLabel] = (entryDataSum[trueLabel] || 0) + entry[2];
+  });
   const entryRatioData = entryData.map((entry) => [
     entry[0],
     entry[1],
-    +(entry[2] / entryDataSum).toFixed(3),
+    +(entry[2] / entryDataSum[entry[0]]).toFixed(3),
   ]);
 
   // Get array min and max

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -55,6 +55,10 @@ export function MetricPane(props: Props) {
     return `${metric} by ${featureDescription}`;
   }
 
+  function generateComboAnalysisChartTitle(feature: string): string {
+    return systemAnalysesParsed[feature][0].featureDescription;
+  }
+
   function getColSpan(): 8 | 12 | 24 {
     const maxRightBoundsLength = Math.max(
       ...Object.values(featureNameToBucketInfo).map(
@@ -168,7 +172,7 @@ export function MetricPane(props: Props) {
               if (feature.toLowerCase().startsWith("combo")) {
                 return (
                   <ComboAnalysisChart
-                    title={generateBarChartTitle(feature)}
+                    title={generateComboAnalysisChartTitle(feature)}
                     colSpan={chartColSpan}
                     systems={systems}
                     analyses={systemAnalysesParsed[feature]}


### PR DESCRIPTION
Solves issue #445

![image](https://user-images.githubusercontent.com/33018020/197678734-a21b556b-09f3-4d7f-a64c-f51e5a17d973.png)

I changed the titles for combo analyses to be `featureDescription`.
Also, the entry values are now calculated as `cooccurrence(true_tag, predicted_tag)/count(true_tag)`.