### PR TITLE
change analysis description to be nullable

### DIFF
--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -211,7 +211,9 @@ export function parseFineGrainedResults(
       );
 
       const analysisName = myResult.name;
-      const analysisDescription = myAnalysis?.description;
+      const analysisDescription = myAnalysis?.description
+        ? myAnalysis.description
+        : analysisName;
       const bucketType = myAnalysis ? myAnalysis["method"] : "";
 
       if (myResult.cls_name === "BucketAnalysisResult") {

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -211,9 +211,7 @@ export function parseFineGrainedResults(
       );
 
       const analysisName = myResult.name;
-      const analysisDescription = myAnalysis?.description
-        ? myAnalysis.description
-        : analysisName;
+      const analysisDescription = myAnalysis?.description || analysisName;
       const bucketType = myAnalysis ? myAnalysis["method"] : "";
 
       if (myResult.cls_name === "BucketAnalysisResult") {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.8"
+  version: "0.2.9"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -612,6 +612,7 @@ components:
       properties:
         description:
           type: string
+          nullable: true
         cls_name:
           type: string
       additionalProperties: true

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -610,11 +610,11 @@ components:
       description: The specification of an analysis to return
       type: object
       properties:
+        cls_name:
+          type: string
         description:
           type: string
           nullable: true
-        cls_name:
-          type: string
       additionalProperties: true
       required: [cls_name]
 


### PR DESCRIPTION
### Allow analysis description to be nullable
When uploading custom analyses without descriptions, the following error will occur and the web will break down.
```
[500] None is not of type 'string' Failed validating 'type' in schema['allOf'][1]['properties']['system_info']['properties']['analyses']['items']['properties']['description']: {'type': 'string'} On instance['system_info']['analyses'][9]['description']: None
```
This is because Analysis's description property is fixed to `string` type. Setting Analysis description to be nullable also makes it consistent with [its SDK setting](https://github.com/neulab/ExplainaBoard/blob/fcedd5d7aab172b943c6b0025685b09744f149fd/explainaboard/analysis/analyses.py#L127). 

### Web chart title change
The chart title is `{metricName} by {analysisDescription}`, and the default analyses's descriptions are the same as the corresponding feature descriptions. Since custom analysis description can be null, use the feature name as analysisDescription when analysis description is not defined. 