### PR TITLE
Analysis table use cases

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -6,6 +6,8 @@ import { AnalysisCase } from "../../../clients/openapi";
 import { PageState } from "../../../utils";
 
 import { taskColumnMapping } from "../AnalysisTable/taskColumnMapping";
+import { joinResults, unnestAnalysisCases } from "../AnalysisTable/utils";
+
 interface Props {
   /** title of the table */
   title: string;
@@ -41,6 +43,23 @@ export function ExampleTable({
     () => systems.map((system) => [system.system_id]),
     [systems]
   );
+  const mergedCases = useMemo(() => {
+    // unnest the features in cases
+    const unnestedCases = [];
+    for (let i = 0; i < cases.length; i++) {
+      unnestedCases.push(unnestAnalysisCases(cases[i], "features"));
+    }
+
+    // join the predictions
+    let finalCases;
+    if (unnestedCases.length > 1 && taskColumns !== undefined) {
+      const predCol = taskColumns.predictionColumns[0].id;
+      finalCases = joinResults(unnestedCases, predCol);
+    } else {
+      finalCases = unnestedCases[0];
+    }
+    return finalCases;
+  }, [cases, taskColumns]);
 
   if (systems.length !== cases.length) {
     console.error(
@@ -55,7 +74,7 @@ export function ExampleTable({
         systemIDs={systemIDs}
         systemNames={systemNames}
         task={task}
-        casesList={cases}
+        cases={mergedCases}
         changeState={changeState}
       />
     );
@@ -74,7 +93,7 @@ export function ExampleTable({
                   systemIDs={systemIDsArray[sysIndex]}
                   systemNames={[system.system_name]}
                   task={task}
-                  casesList={[cases[sysIndex]]}
+                  cases={cases[sysIndex]}
                   changeState={changeState}
                 />
               </Tabs.TabPane>

--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -55,7 +55,7 @@ export function ExampleTable({
         systemIDs={systemIDs}
         systemNames={systemNames}
         task={task}
-        cases={cases[0]}
+        casesList={cases}
         changeState={changeState}
       />
     );
@@ -74,7 +74,7 @@ export function ExampleTable({
                   systemIDs={systemIDsArray[sysIndex]}
                   systemNames={[system.system_name]}
                   task={task}
-                  cases={cases[sysIndex]}
+                  casesList={[cases[sysIndex]]}
                   changeState={changeState}
                 />
               </Tabs.TabPane>

--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -93,7 +93,7 @@ export function ExampleTable({
                   systemIDs={systemIDsArray[sysIndex]}
                   systemNames={[system.system_name]}
                   task={task}
-                  casesList={[cases[sysIndex]]}
+                  cases={cases[sysIndex]}
                   changeState={changeState}
                 />
               </Tabs.TabPane>

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -157,7 +157,7 @@ function specifyDataSeqLab(
 
     for (let i = 0; i < cases.length; i++) {
       // Get the outputs from the bucket case
-      const origToks = cases[i]["tokens"];
+      const origToks = systemOutputs[i]["tokens"];
       const sentence = Array.isArray(origToks) ? origToks.join(" ") : origToks;
       const dataRow = {
         sentence: sentence,

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -181,6 +181,7 @@ export function AnalysisTable({
   const cases = casesList[0];
   const [page, setPage] = useState(0);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
+  const [casesThisPage, setCasesThisPage] = useState<AnalysisCase[]>([]);
   const pageSize = 10;
   const total = cases.length;
   const tableRef = useRef<null | HTMLDivElement>(null);
@@ -195,7 +196,8 @@ export function AnalysisTable({
       try {
         const offset = page * pageSize;
         const end = Math.min(offset + pageSize, cases.length);
-        const outputIDs = cases.slice(offset, end).map((x) => x.sample_id);
+        const casesThisPage = cases.slice(offset, end);
+        const outputIDs = casesThisPage.map((x) => x.sample_id);
         let joinedResult: SystemOutput[] = [];
         const results = [];
         for (const systemID of systemIDs) {
@@ -216,6 +218,7 @@ export function AnalysisTable({
         }
 
         setSystemOutputs(joinedResult);
+        setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {
@@ -258,7 +261,7 @@ export function AnalysisTable({
   const numSystems = systemIDs.length;
   const taskCols = taskColumnMapping.get(task);
   if (seqLabTasks.includes(task)) {
-    dataSource = specifyDataSeqLab(systemOutputs, cases, columns);
+    dataSource = specifyDataSeqLab(systemOutputs, casesThisPage, columns);
   } else if (taskCols !== undefined) {
     colInfo = addPredictionColInfo(task, systemNames);
     /* expand columns if it is multi-system analysis */

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -202,8 +202,8 @@ export function AnalysisTable({
           outputIDs
         );
 
-        setSystemOutputs(result);
         setCasesThisPage(casesThisPage);
+        setSystemOutputs(result);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   systemIDs: string[];
   systemNames: string[];
   task: string;
-  cases: AnalysisCase[];
+  casesList: AnalysisCase[][];
   changeState: (newState: PageState) => void;
 }
 
@@ -174,9 +174,11 @@ export function AnalysisTable({
   systemIDs,
   systemNames,
   task,
-  cases,
+  casesList,
   changeState,
 }: Props) {
+  // the cases for each system are the same except for predicted_label
+  const cases = casesList[0];
   const [page, setPage] = useState(0);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
   const pageSize = 10;

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -8,13 +8,13 @@ import {
   taskColumnMapping,
   seqLabTasks,
 } from "../AnalysisTable/taskColumnMapping";
-import { joinResults, addPredictionColInfo, unnestSystemOutput } from "./utils";
+import { addPredictionColInfo, unnestAnalysisCases } from "./utils";
 
 interface Props {
   systemIDs: string[];
   systemNames: string[];
   task: string;
-  casesList: AnalysisCase[][];
+  cases: AnalysisCase[];
   changeState: (newState: PageState) => void;
 }
 
@@ -81,37 +81,37 @@ function createSentenceForSeqLab(
 }
 
 function specifyDataGeneric(
-  systemOutputs: SystemOutput[],
+  cases: AnalysisCase[],
   columns: ColumnsType<SystemOutput>,
   colInfo: { [key: string]: string }[] | undefined = undefined
 ): { [key: string]: string }[] {
-  const systemOutputFirst = systemOutputs[0];
+  const casesFirst = cases[0];
 
   colInfo =
     colInfo !== undefined
       ? colInfo
-      : Object.keys(systemOutputFirst).map((x) => {
+      : Object.keys(casesFirst).map((x) => {
           return { id: x, name: x };
         });
   renderColInfo(columns, colInfo);
 
   // clone the system output for modification
-  return systemOutputs.map(function (systemOutput) {
-    const processedSystemOutput = { ...systemOutput };
-    for (const [key, output] of Object.entries(systemOutput)) {
+  return cases.map(function (cas) {
+    const processedCases = { ...cas };
+    for (const [key, output] of Object.entries(cas)) {
       /*Task like QA have object output besides string and number.
         For now we serialize the object to a displayable string.
         TODO: unnest or use a nested table
       */
       if (typeof output === "object") {
-        processedSystemOutput[key] = Object.entries(output)
+        processedCases[key] = Object.entries(output)
           .map(([subKey, subOutput]) => {
             return `${subKey}: ${subOutput}`;
           })
           .join("\n");
       }
     }
-    return processedSystemOutput;
+    return processedCases;
   });
 }
 
@@ -133,7 +133,7 @@ function specifyDataSeqLab(
 
     renderColInfo(columns, colInfo);
 
-    for (let i = 0; i < systemOutputs.length; i++) {
+    for (let i = 0; i < cases.length; i++) {
       // Get the outputs from the bucket case
       const sentence = createSentenceForSeqLab(systemOutputs[i], cases[i]);
       const pos = cases[i]["token_span"];
@@ -155,9 +155,9 @@ function specifyDataSeqLab(
 
     renderColInfo(columns, colInfo);
 
-    for (let i = 0; i < systemOutputs.length; i++) {
+    for (let i = 0; i < cases.length; i++) {
       // Get the outputs from the bucket case
-      const origToks = systemOutputs[i]["tokens"];
+      const origToks = cases[i]["tokens"];
       const sentence = Array.isArray(origToks) ? origToks.join(" ") : origToks;
       const dataRow = {
         sentence: sentence,
@@ -174,11 +174,9 @@ export function AnalysisTable({
   systemIDs,
   systemNames,
   task,
-  casesList,
+  cases,
   changeState,
 }: Props) {
-  // the cases for each system are the same except for predicted_label
-  const cases = casesList[0];
   const [page, setPage] = useState(0);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
   const [casesThisPage, setCasesThisPage] = useState<AnalysisCase[]>([]);
@@ -198,26 +196,13 @@ export function AnalysisTable({
         const end = Math.min(offset + pageSize, cases.length);
         const casesThisPage = cases.slice(offset, end);
         const outputIDs = casesThisPage.map((x) => x.sample_id);
-        let joinedResult: SystemOutput[] = [];
-        const results = [];
-        for (const systemID of systemIDs) {
-          const result = await backendClient.systemOutputsGetById(
-            systemID,
-            outputIDs
-          );
-          results.push(result);
-        }
 
-        // join the results if it is one of the supported tasks and is multi-system
-        const taskCols = taskColumnMapping.get(task);
-        if (results.length > 1 && taskCols !== undefined) {
-          const predCol = taskCols.predictionColumns[0].id;
-          joinedResult = joinResults(results, predCol);
-        } else {
-          joinedResult = results[0];
-        }
+        const result = await backendClient.systemOutputsGetById(
+          systemIDs[0],
+          outputIDs
+        );
 
-        setSystemOutputs(joinedResult);
+        setSystemOutputs(result);
         setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
@@ -250,12 +235,11 @@ export function AnalysisTable({
   }, [page, pageSize, cases, changeState, systemIDs, task]);
 
   // other fields
-  if (systemOutputs.length === 0) {
+  if (casesThisPage.length === 0) {
     return <div>System outputs will display here.</div>;
   }
 
   const columns: ColumnsType<SystemOutput> = [];
-
   let dataSource: { [p: string]: string }[];
   let colInfo;
   const numSystems = systemIDs.length;
@@ -267,15 +251,24 @@ export function AnalysisTable({
     /* expand columns if it is multi-system analysis */
     if (numSystems > 1) {
       dataSource = specifyDataGeneric(
-        unnestSystemOutput(systemOutputs, taskCols.predictionColumns[0].id),
+        unnestAnalysisCases(casesThisPage, taskCols.predictionColumns[0].id),
         columns,
         colInfo
       );
     } else {
-      dataSource = specifyDataGeneric(systemOutputs, columns, colInfo);
+      dataSource = specifyDataGeneric(casesThisPage, columns, colInfo);
     }
   } else {
-    dataSource = specifyDataGeneric(systemOutputs, columns);
+    dataSource = specifyDataGeneric(casesThisPage, columns);
+  }
+
+  // add id to dataSource
+  for (let i = 0; i < dataSource.length; i++) {
+    for (const [key, value] of Object.entries(dataSource[i])) {
+      if (key === "sample_id") {
+        dataSource[i]["id"] = value;
+      }
+    }
   }
 
   return (


### PR DESCRIPTION
Blocked by #448 

### Background
The examples we show in the table should be derived from the `cases` in each bucket instead of the `systemOutputs`. The examples already exist in the `cases` argument which are passed in while creating the AnalysisTable component, so the API `backendClient.systemOutputsGetById()` should only be used to retrieve sentences in the dataset and not for model predictions.

### Changes in this PR
- use `cases` instead of `systemOutputs` to get the examples
- call `backendClient.systemOutputsGetById()` only once to get the true sentences in dataset
- change type in functions from `AnalysisCase` to _SystemOutput_ in `utils.tsx` —> because we are now using `AnalysisCase` instead of `systemOutput` as mentioned in bullet point 1