### PR TITLE
feat: added combo count analysis chart axes titles

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -137,12 +137,24 @@ export function ComboAnalysisChart(props: Props) {
       splitArea: {
         show: true,
       },
+      name: analysis.comboFeatures[1],
+      nameLocation: "middle",
+      nameTextStyle: {
+        padding: [1, 0, 0, 0],
+        fontSize: 10,
+        fontWeight: "bold",
+      },
     },
     yAxis: {
       type: "category",
       data: categories,
       splitArea: {
         show: true,
+      },
+      name: analysis.comboFeatures[0],
+      nameTextStyle: {
+        fontWeight: "bold",
+        fontSize: 10,
       },
     },
     visualMap: {

--- a/frontend/src/components/Analysis/types.tsx
+++ b/frontend/src/components/Analysis/types.tsx
@@ -24,6 +24,8 @@ export interface ResultFineGrainedParsed {
   performances: Performance[];
   // Used by combo count analyses
   comboCounts: ComboCount[];
+  // Combo count analyses features. Used by combo count analyses
+  comboFeatures: string[];
   // levelName: is the level that this result belongs to
   levelName: string;
   // cases[i][j]: is the index of the ith bucket's jth example

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -24,6 +24,7 @@ export function initParsedResult(
   const bucketType = "";
   const performances: ResultFineGrainedParsed["performances"] = [];
   const comboCounts: ResultFineGrainedParsed["comboCounts"] = [];
+  const comboFeatures: ResultFineGrainedParsed["comboFeatures"] = [];
   const cases: ResultFineGrainedParsed["cases"] = [];
   const numbersOfSamples: ResultFineGrainedParsed["numbersOfSamples"] = [];
   return {
@@ -37,6 +38,7 @@ export function initParsedResult(
     numbersOfSamples,
     performances,
     comboCounts,
+    comboFeatures,
     cases,
   };
 }
@@ -62,6 +64,7 @@ export function formatBucketName(unformattedName: Array<number>): string {
 
 export function parseComboCountFeatures(
   comboCounts: AnalysisResult[],
+  features: string[],
   levelName: string,
   analysisName: string,
   featureDescription: string
@@ -80,6 +83,7 @@ export function parseComboCountFeatures(
       samples: countArr[2],
     };
   });
+  parsedResult.comboFeatures = features;
 
   return parsedResult;
 }
@@ -235,6 +239,7 @@ export function parseFineGrainedResults(
       } else if (myResult.cls_name === "ComboCountAnalysisResult") {
         const parsedComboAnalysis = parseComboCountFeatures(
           myResult["combo_counts"],
+          myResult.features,
           myResult.level,
           analysisName,
           analysisDescription


### PR DESCRIPTION
Follow-up for PR #451: added title for combo count chart. See below

![image](https://user-images.githubusercontent.com/33018020/198088467-736f6ba5-2ff8-4650-9403-6f101be0129f.png)

Also, I am assuming the labels follows the same order as `features` field in the object returned from backend (see below). Can someone double check whether the axes names are correct (not the other way around)? 

```json
{
          "cls_name": "ComboCountAnalysisResult",
          "combo_counts": [
            [
              [
                "positive",
                "positive"
              ],
              791
            ],
            [
              [
                "negative",
                "positive"
              ],
              100
            ],
            [
              [
                "positive",
                "negative"
              ],
              118
            ],
            [
              [
                "negative",
                "negative"
              ],
              812
            ]
          ],
          "features": [   // here
            "true_label",
            "predicted_label"
          ],
          "level": "example",
          "name": "combo(true_label,predicted_label)"
        },
```
