### PR TITLE
db_schema: system_info.results.overall -> results

### DIFF
--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -111,6 +111,13 @@ def user_get() -> modelUser:
 
 
 def tasks_get() -> list[TaskCategory]:
+    """Returns a list of task categories and metadata for each
+    task.
+    NOTE: supported_metrics only returns metrics for the example
+    level. This is because the SDK does not provide a way to configure
+    the list of metrics for other analysis levels. This should be fixed
+    in the future.
+    """
     _categories = get_task_categories()
     categories: list[TaskCategory] = []
     for _category in _categories:
@@ -267,6 +274,13 @@ def systems_get(
     creator: str | None,
     shared_users: list[str] | None,
 ) -> SystemsReturn:
+    """Returns a systems according to the provided filters
+
+    Args:
+        sort_field: created_at or a field within results. `results` has two levels:
+            analysis level and metric so the field should be provided as a dot separated
+            value (e.g. example.F1)
+    """
     if not sort_field:
         sort_field = "created_at"
     if not sort_direction:
@@ -274,7 +288,7 @@ def systems_get(
     if sort_direction not in ["asc", "desc"]:
         abort_with_error_message(400, "sort_direction needs to be one of asc or desc")
     if sort_field != "created_at":
-        sort_field = f"system_info.results.overall.{sort_field}.value"
+        sort_field = f"results.{sort_field}"
 
     dir = ASCENDING if sort_direction == "asc" else DESCENDING
 

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -15,7 +15,6 @@ import { SystemModel } from "../../models";
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import { PrivateIcon, useUser } from "..";
 import { generateLeaderboardURL } from "../../utils";
-import { getOverallMap } from "../Analysis/utils";
 const { Text } = Typography;
 
 interface Props {
@@ -48,11 +47,9 @@ export function SystemTableContent({
 }: Props) {
   const { userInfo } = useUser();
   const metricColumns: ColumnsType<SystemModel> = metricNames.map((metric) => ({
-    dataIndex: metric,
-    render: (_, record) =>
-      getOverallMap(record.system_info.results.overall)[metric]?.value,
+    dataIndex: ["results", ...metric.split(".")],
     title: metric,
-    width: 100,
+    width: 135,
     ellipsis: true,
     align: "center",
   }));

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.8"
+  version: "0.2.9"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -307,10 +307,12 @@ paths:
             default: 20
         - in: query
           name: sort_field
-          description: supports `created_at` (default) and metric names.
+          description: >
+            Supports `created_at` (default) and metric names. Metric names should be
+            provided as {analysis_level}.{metric_name}
           schema:
             type: string
-            example: Accuracy
+            example: example.Accuracy
         - in: query
           name: sort_direction
           schema:
@@ -982,6 +984,13 @@ components:
               description: the user who created the system
             preferred_username:
               type: string
+            results:
+              type: object
+              example: {"span": {"F1": 0.9221}}
+              additionalProperties:
+                type: object
+                additionalProperties:
+                  type: number
             shared_users:
               type: array
               items:
@@ -1016,6 +1025,7 @@ components:
             - source_language
             - target_language
             - task
+            - results
             - system_info
             - metric_stats
         - $ref: "#/components/schemas/Time"


### PR DESCRIPTION
part of #433 
fixes #320 

This is the last PR for the first step. It moves overall metrics out of `system_info` and stores something like this for each system.
```
"results": {
  "example": { "rouge1": 0.33, ...},
  "token": { "F1": 0.35, ... }
}
```

Previously, the endpoints and the UI does not specify the analysis level for each metric which can be confusing because metrics can have the same name for different analysis levels. This PR fixes this issue partially. 
- Now, the systems table page displays the levels. The corresponding endpoint (GET /systems) is also updated to include this information.
<img width="1729" alt="image" src="https://user-images.githubusercontent.com/22896307/198163881-d5267c79-7f26-4ac5-ae19-ef9d7c895ec5.png">
The headers become even more verbose. We can group the column headers to make it easier to read but I'll leave it for another PR. 
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/22896307/198164236-3d089117-f1dc-436b-be3c-3fff2cf645f9.png">

- The system submission UI and the endpoint (POST /systems) remain the same because updating those would break the python client. Also, the SDK does not support the configuration of other analysis levels at the moment.
