### PR TITLE
fix error due to empty casesThisPage

### DIFF
--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -217,8 +217,8 @@ export function AnalysisTable({
           joinedResult = results[0];
         }
 
-        setSystemOutputs(joinedResult);
         setCasesThisPage(casesThisPage);
+        setSystemOutputs(joinedResult);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {


### PR DESCRIPTION
Fix issue #462 

This error is caused by an empty `casesThisPage` in the function `specifyDataSeqLab`, which is due to the async property of function `refreshSystemOutputs`. To avoid this, update `casesThisPage` before updating `systemOutputs` so that this condition will guarantee that the lengths of `systemOutputs` and `casesThisPage` are the same.
```
if (systemOutputs.length === 0) {
    return <div>System outputs will display here.</div>;
  }
```