### PR TITLE
move order of casesThisPage

### DIFF
--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -202,8 +202,8 @@ export function AnalysisTable({
           outputIDs
         );
 
-        setCasesThisPage(casesThisPage);
         setSystemOutputs(result);
+        setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {


### PR DESCRIPTION
The fix in PR #455 contains a bug.
Changing the condition to `If (casesThisPage.length === 0)`, means that the condition depends on which variable is lastly updated. It should be
```
setSystemOutputs(joinedResult);
setCasesThisPage(casesThisPage);
...
if (casesThisPage.length === 0)
```