### PR TITLE
Remove cases this page

### DIFF
--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -179,7 +179,6 @@ export function AnalysisTable({
 }: Props) {
   const [page, setPage] = useState(0);
   const [systemOutputs, setSystemOutputs] = useState<SystemOutput[]>([]);
-  const [casesThisPage, setCasesThisPage] = useState<AnalysisCase[]>([]);
   const pageSize = 10;
   const total = cases.length;
   const tableRef = useRef<null | HTMLDivElement>(null);
@@ -188,14 +187,14 @@ export function AnalysisTable({
     setPage(0);
   }, [cases]);
 
+  const offset = page * pageSize;
+  const end = Math.min(offset + pageSize, cases.length);
+
   useEffect(() => {
     async function refreshSystemOutputs() {
       changeState(PageState.loading);
       try {
-        const offset = page * pageSize;
-        const end = Math.min(offset + pageSize, cases.length);
-        const casesThisPage = cases.slice(offset, end);
-        const outputIDs = casesThisPage.map((x) => x.sample_id);
+        const outputIDs = cases.slice(offset, end).map((x) => x.sample_id);
 
         const result = await backendClient.systemOutputsGetById(
           systemIDs[0],
@@ -203,7 +202,6 @@ export function AnalysisTable({
         );
 
         setSystemOutputs(result);
-        setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {
@@ -232,10 +230,10 @@ export function AnalysisTable({
     users will not experience a delay due to the async API call.
     */
     tableRef.current?.scrollIntoView();
-  }, [page, pageSize, cases, changeState, systemIDs, task]);
+  }, [page, pageSize, cases, changeState, systemIDs, task, offset, end]);
 
   // other fields
-  if (casesThisPage.length === 0) {
+  if (systemOutputs.length === 0) {
     return <div>System outputs will display here.</div>;
   }
 
@@ -244,6 +242,7 @@ export function AnalysisTable({
   let colInfo;
   const numSystems = systemIDs.length;
   const taskCols = taskColumnMapping.get(task);
+  const casesThisPage = cases.slice(offset, end);
   if (seqLabTasks.includes(task)) {
     dataSource = specifyDataSeqLab(systemOutputs, casesThisPage, columns);
   } else if (taskCols !== undefined) {

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -202,8 +202,8 @@ export function AnalysisTable({
           outputIDs
         );
 
-        setCasesThisPage(casesThisPage);
         setSystemOutputs(result);
+        setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {


### PR DESCRIPTION
Blocked by #465 

This is suggested by @lyuyangh and @qjiang002 from PR #463. But because there was a PR #455 merged after the suggestion, some parts are a bit different. I think it's better if it is pulled out as a new PR.

In this PR, the `casesThisPage` is removed as a state so the page won't be needed to re-render twice due to both cases and systemOutputs.