### PR TITLE
remove extra setCasesThisPage

### DIFF
--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -202,7 +202,6 @@ export function AnalysisTable({
         );
 
         setSystemOutputs(result);
-        setCasesThisPage(casesThisPage);
       } catch (e) {
         console.log("error", e);
         if (e instanceof Response) {


### PR DESCRIPTION
Not sure why but it seems that #466 wasn't merged properly and it left an extra line in `AnalysisTable/index.tsx`. This PR removes that line.