### PR TITLE
fix page navigation

### DIFF
--- a/frontend/src/components/BenchmarkCards/index.tsx
+++ b/frontend/src/components/BenchmarkCards/index.tsx
@@ -22,7 +22,7 @@ export function BenchmarkCards({ items, subtitle }: Props) {
         <title>ExplainaBoard - Benchmarks</title>
       </Helmet>
       <PageHeader
-        onBack={() => history.goBack()}
+        onBack={() => history.push("/")}
         title="Benchmarks"
         subTitle={subtitle}
       />

--- a/frontend/src/pages/DatasetsPage/index.tsx
+++ b/frontend/src/pages/DatasetsPage/index.tsx
@@ -10,7 +10,6 @@ import {
   PageState,
 } from "../../utils";
 import { useHistory } from "react-router";
-import { Link } from "react-router-dom";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 import { Helmet } from "react-helmet";
 import { ModalForImportTip } from "../../components/DatasetComponent";
@@ -76,7 +75,7 @@ export function DatasetsPage() {
           <title>ExplainaBoard - Datasets</title>
         </Helmet>
         <PageHeader
-          onBack={() => history.goBack()}
+          onBack={() => history.push("/")}
           title="Datasets"
           subTitle="A list of all supported datasets"
           className="header"
@@ -167,16 +166,16 @@ const columns: ColumnsType<DatasetMetadata> = [
       return splits.map((split) => {
         return (
           <div key={split}>
-            <Link
-              to={generateLeaderboardURL(
+            <Typography.Link
+              href={generateLeaderboardURL(
                 record.dataset_name,
                 record.sub_dataset,
                 split
               )}
-              component={Typography.Link}
+              target="_blank"
             >
               {split}
-            </Link>
+            </Typography.Link>
           </div>
         );
       });

--- a/frontend/src/pages/LeaderboardPage/index.tsx
+++ b/frontend/src/pages/LeaderboardPage/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import "./index.css";
 import { PageHeader } from "antd";
-import { useHistory } from "react-router-dom";
 import { SystemsTable } from "../../components";
 import { LeaderboardHome } from "../LeaderboardHome";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
@@ -14,7 +13,6 @@ import useQuery from "../../components/useQuery";
  */
 export function LeaderboardPage() {
   useGoogleAnalytics();
-  const history = useHistory();
   const query = useQuery();
   const task = query.get("task") || undefined;
   const dataset = query.get("dataset") || undefined;
@@ -42,7 +40,7 @@ export function LeaderboardPage() {
           <title>ExplainaBoard - {title} Leaderboard</title>
         </Helmet>
         <PageHeader
-          onBack={() => history.goBack()}
+          backIcon={false}
           title={title + " Leaderboard"}
           subTitle={`Leaderboard for ${subTitle}`}
         />

--- a/frontend/src/pages/SystemsPage/index.tsx
+++ b/frontend/src/pages/SystemsPage/index.tsx
@@ -19,7 +19,7 @@ export function SystemsPage() {
         <title>ExplainaBoard - Systems</title>
       </Helmet>
       <PageHeader
-        onBack={() => history.goBack()}
+        onBack={() => history.push("/")}
         title="Systems"
         subTitle="All systems submitted by users"
         className="header"


### PR DESCRIPTION
## Fix back button page navigation
* The back button next to page header on the Datasets, Systems, Benchmarks pages should navigate back to Home page, but now it leads to the last history page. For example, if the view order is `Datasets -> Benchmarks -> Systems`, when keeping clicking on the back button, the navigation order is `Systems -> Benchmarks -> Datasets -> Homepage`. 
* The back button on the leaderboard page doesn't work.
![Screen Shot 2022-10-29 at 11 53 53 AM](https://user-images.githubusercontent.com/71625258/198842883-448ba736-88fc-4a24-8f8b-d3bc99223648.png)

## Fixes
* The back button on Datasets, Systems, Benchmarks pages links to Home page.
* When clicking on the datasets, open another tab for the corresponding leaderboards, and remove the back button.
![Screen Shot 2022-10-29 at 12 21 05 PM](https://user-images.githubusercontent.com/71625258/198842962-6e6be440-3e38-4145-8f57-2a088a18ba4c.png)
