### PR TITLE
add confidence scores to overall_metrics

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -352,7 +352,7 @@ class SystemDBUtils:
         """
 
         def _validate_and_create_system():
-            system = {"results": {}}
+            system = {"overall_metrics": {}}
 
             user = get_user()
             system["creator"] = user.id
@@ -444,11 +444,11 @@ class SystemDBUtils:
                 for level, result in zip(
                     sys_info.analysis_levels, sys_info.results.overall
                 ):
-                    system.results[level.name] = {}
+                    system.overall_metrics[level.name] = {}
                     for metric_result in result:
-                        system.results[level.name][
+                        system.overall_metrics[level.name][
                             metric_result.metric_name
-                        ] = metric_result.value
+                        ] = metric_result
 
             def db_operations(session: ClientSession) -> str:
                 # Insert system

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -277,9 +277,9 @@ def systems_get(
     """Returns a systems according to the provided filters
 
     Args:
-        sort_field: created_at or a field within results. `results` has two levels:
-            analysis level and metric so the field should be provided as a dot separated
-            value (e.g. example.F1)
+        sort_field: created_at or a field within overall_metrics. `overall_metrics`
+            has two levels: analysis level and metric so the field should be
+            provided as a dot separated value (e.g. example.F1)
     """
     if not sort_field:
         sort_field = "created_at"
@@ -288,7 +288,7 @@ def systems_get(
     if sort_direction not in ["asc", "desc"]:
         abort_with_error_message(400, "sort_direction needs to be one of asc or desc")
     if sort_field != "created_at":
-        sort_field = f"results.{sort_field}"
+        sort_field = f"overall_metrics.{sort_field}.value"
 
     dir = ASCENDING if sort_direction == "asc" else DESCENDING
 

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -47,7 +47,7 @@ export function SystemTableContent({
 }: Props) {
   const { userInfo } = useUser();
   const metricColumns: ColumnsType<SystemModel> = metricNames.map((metric) => ({
-    dataIndex: ["results", ...metric.split(".")],
+    dataIndex: ["overall_metrics", ...metric.split("."), "value"],
     title: metric,
     width: 135,
     ellipsis: true,

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -67,7 +67,7 @@ export function SystemsTable() {
   function getMetricsNames(): string[] {
     const metricNames = new Set<string>();
     for (const sys of systems) {
-      for (const [level, metrics] of Object.entries(sys.results)) {
+      for (const [level, metrics] of Object.entries(sys.overall_metrics)) {
         Object.keys(metrics).forEach((name) =>
           metricNames.add(`${level}.${name}`)
         );

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.10"
+  version: "0.2.11"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -985,13 +985,22 @@ components:
               description: the user who created the system
             preferred_username:
               type: string
-            results:
+            overall_metrics:
               type: object
-              example: {"span": {"F1": 0.9221}}
+              example: {
+                "span": {
+                  "F1": {
+                    "metric_name": "F1",
+                    "value": 0.76,
+                    "confidence_score_low": 0.75,
+                    "confidence_score_high": 0.77
+                  }
+                }
+              }
               additionalProperties:
                 type: object
                 additionalProperties:
-                  type: number
+                  $ref: "#/components/schemas/Performance"
             shared_users:
               type: array
               items:
@@ -1026,7 +1035,7 @@ components:
             - source_language
             - target_language
             - task
-            - results
+            - overall_metrics
             - system_info
             - metric_stats
         - $ref: "#/components/schemas/Time"


### PR DESCRIPTION
I didn't realize that `explainaboard_client` also requires that confidence scores be retrieved for each system. This PR adds that information to the DB and to the `System` model. I decided to rename the field to `overall_metrics` so this PR won't break the dev environment while it is still being reviewed. I also submitted a [PR](https://github.com/neulab/explainaboard_client/pull/54) that upgrades `explainaboard_client` to be compatible with API v0.2.11.