### PR TITLE
use EB_ENV instead of FLASK_ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /bin/bash ./openapi/gen_api_layer.sh backend \
 WORKDIR /app/backend/src/gen
 # Run app in production mode by default. Override this env to run in
 # development or in staging
-ENV FLASK_ENV production
+ENV EB_ENV production
 
 COPY --from=build-step /app/frontend/build /usr/share/nginx/html
 COPY deployment/nginx.conf /etc/nginx/sites-enabled/default

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -91,7 +91,7 @@ def info_get():
     if not api_version:
         raise RuntimeError("failed to extract API version")
     return {
-        "env": os.getenv("FLASK_ENV"),
+        "env": os.getenv("EB_ENV"),
         "auth_url": current_app.config.get("AUTH_URL"),
         "api_version": api_version,
     }

--- a/backend/src/impl/init.py
+++ b/backend/src/impl/init.py
@@ -15,10 +15,10 @@ def init(app: Flask) -> Flask:
 
 
 def _init_config(app: Flask):
-    flask_env = os.getenv("FLASK_ENV")
-    if flask_env == "production":
+    env = os.getenv("EB_ENV")
+    if env == "production":
         app.config.from_object(ProductionConfig())
-    elif flask_env == "development":
+    elif env == "development":
         app.config.from_object(LocalDevelopmentConfig())
-    elif flask_env == "staging":
+    elif env == "staging":
         app.config.from_object(StagingConfig())

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "start": "concurrently \"npm run start-backend\" \"npm run start-frontend\"",
     "start-frontend": "npm --prefix frontend run start",
-    "start-backend": "cd backend/src/gen && FLASK_ENV=development python -m explainaboard_web",
-    "start-backend:staging": "cd backend/src/gen && FLASK_ENV=staging python -m explainaboard_web",
-    "start-backend:prod": "cd backend/src/gen && FLASK_ENV=production python -m explainaboard_web",
+    "start-backend": "cd backend/src/gen && EB_ENV=development python -m explainaboard_web",
+    "start-backend:staging": "cd backend/src/gen && EB_ENV=staging python -m explainaboard_web",
+    "start-backend:prod": "cd backend/src/gen && EB_ENV=production python -m explainaboard_web",
     "gen-api-code": "bash openapi/gen_api_layer.sh project",
     "setup": "npm install && npm run gen-api-code && pip install -r backend/requirements.txt -r backend/src/gen/requirements.txt && npm --prefix frontend install",
     "prepare": "husky install",


### PR DESCRIPTION
fixes #358 
We have been using `FLASK_ENV` as the environment identifier but it is deprecated in flask 2.2 which prevents `DEBUG` from being configured properly according to the environment. I renamed it to `EB_ENV` in this PR and the `DEBUG` mode works again now.