### PR TITLE
Fix analysis systems with same names

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -203,7 +203,7 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
     const duplicateNameWarning =
       distinctSystemNames.size !== systemNames.length;
     const duplicateNameWarningMsg =
-      "The systems have duplicate names. Unique system IDs are attached to distinguish between them. Please change system names for a better presentation.";
+      "The systems have duplicate names. Unique system IDs are attached to distinguish between them. Please change system names using the edit button on `Systems` page.";
     if (systems.length === 1) {
       return `Single Analysis of ${systems[0].system_name}`;
     } else if (systems.length === 2) {

--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Drawer, Spin } from "antd";
+import { Drawer, Spin, Tooltip } from "antd";
 import { SystemModel } from "../../../models";
 import { ErrorBoundary, AnalysisReport } from "../../../components";
 import { PageState } from "../../../utils";
@@ -8,6 +8,7 @@ import {
   SystemAnalysesReturn,
   SystemsAnalysesBody,
 } from "../../../clients/openapi";
+import { WarningOutlined } from "@ant-design/icons";
 import { parseFineGrainedResults, valuesToIntervals } from "../utils";
 import { ResultFineGrainedParsed, BucketIntervals } from "../types";
 import ReactGA from "react-ga4";
@@ -196,14 +197,38 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
     setBucketInfoUpdated(false);
   }
 
-  function getDrawerTitle(): string {
+  function getDrawerTitle(): React.ReactNode {
+    const systemNames = systems.map((sys) => sys.system_name);
+    const distinctSystemNames = new Set(systemNames);
+    const duplicateNameWarning =
+      distinctSystemNames.size !== systemNames.length;
+    const duplicateNameWarningMsg =
+      "The systems have duplicate names. Unique system IDs are attached to distinguish between them. Please change system names for a better presentation.";
     if (systems.length === 1) {
       return `Single Analysis of ${systems[0].system_name}`;
     } else if (systems.length === 2) {
       const systemNames = systems.map((sys) => sys.system_name).join(" and ");
-      return `Pairwise Analysis of ${systemNames}`;
+      return (
+        <div>
+          Pairwise Analysis of {systemNames}{" "}
+          {duplicateNameWarning && (
+            <Tooltip title={duplicateNameWarningMsg}>
+              <WarningOutlined />
+            </Tooltip>
+          )}
+        </div>
+      );
     }
-    return "Analysis";
+    return (
+      <div>
+        Analysis{" "}
+        {duplicateNameWarning && (
+          <Tooltip title={duplicateNameWarningMsg}>
+            <WarningOutlined />
+          </Tooltip>
+        )}
+      </div>
+    );
   }
 
   function renderDrawerContent(): React.ReactElement {

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -30,7 +30,16 @@ export function FineGrainedBarChart(props: Props) {
     onBarClick,
   } = props;
   // For invariant variables across all systems, we can simply take from the first result
-  const systemNames = systems.map((system) => system.system_name);
+  function getSystemNames(systems: SystemModel[]) {
+    const systemNames = systems.map((sys) => sys.system_name);
+    const distinctSystemNames = new Set(systemNames);
+    if (distinctSystemNames.size !== systemNames.length) {
+      return systems.map((sys) => sys.system_name + "_" + sys.system_id);
+    } else {
+      return systemNames;
+    }
+  }
+  const systemNames = getSystemNames(systems);
   const resultFirst = results[0];
   const bucketNames = resultFirst.bucketNames;
   const featureName = resultFirst.featureName;

--- a/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
@@ -16,7 +16,16 @@ export function OverallMetricsBarChart({
   metricNames,
   onBarClick,
 }: Props) {
-  const systemNames = systems.map((system) => system.system_name);
+  function getSystemNames(systems: SystemModel[]) {
+    const systemNames = systems.map((sys) => sys.system_name);
+    const distinctSystemNames = new Set(systemNames);
+    if (distinctSystemNames.size !== systemNames.length) {
+      return systems.map((sys) => sys.system_name + "_" + sys.system_id);
+    } else {
+      return systemNames;
+    }
+  }
+  const systemNames = getSystemNames(systems);
   const resultsValues: number[][] = [];
   const resultsNumbersOfSamples: number[][] = [];
   const resultsConfidenceScores: Array<[number, number]>[] = [];

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -43,7 +43,6 @@ export function SystemTableTools({
   selectedSystemIDs,
   onActiveSystemChange,
 }: Props) {
-  console.log("selectedSystemIDs", selectedSystemIDs);
   function findSelectedSystemDatasetNames(selectedSystems: SystemModel[]) {
     return new Set<string>(
       selectedSystems.map((sys) => sys.dataset?.dataset_name || "unspecified")

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -51,9 +51,7 @@ export function SystemTableTools({
   function hasDuplicateSelectedSystemNames(selectedSystems: SystemModel[]) {
     const selectedSystemNames = selectedSystems.map((sys) => sys.system_name);
     const distinctSystemNames = new Set(selectedSystemNames);
-    return distinctSystemNames.size !== selectedSystemNames.length
-      ? true
-      : false;
+    return distinctSystemNames.size !== selectedSystemNames.length;
   }
   const selectedSystems = systems.filter((sys) =>
     selectedSystemIDs.includes(sys.system_id)
@@ -135,8 +133,8 @@ export function SystemTableTools({
         Analysis
       </Button>
     );
-    // Pairwise analysis
-  } else if (selectedSystemIDs.length === 2) {
+    // Pairwise or multiple system analysis
+  } else {
     let disabled = false;
     let warning = false;
     let tooltipMessage = "";
@@ -159,40 +157,9 @@ export function SystemTableTools({
         disabled={disabled}
         onClick={() => onActiveSystemChange(selectedSystemIDs)}
       >
-        Pairwise Analysis
-        {warning && <WarningOutlined />}
-      </Button>
-    );
-    if (tooltipMessage !== "") {
-      analysisButton = (
-        <Tooltip title={tooltipMessage}>{analysisButton}</Tooltip>
-      );
-    }
-    // three or more systems
-  } else if (selectedSystemIDs.length >= 3) {
-    let disabled = false;
-    let warning = false;
-    let tooltipMessage = "";
-    if (selectedSystemDatasetNames.has("unspecified")) {
-      warning = true;
-      tooltipMessage =
-        "Unspecified dataset name detected. Proceed if you are certain the systems use the same dataset.";
-    } else if (selectedSystemDatasetNames.size > 1) {
-      disabled = true;
-      tooltipMessage =
-        "Cannot perform multiple analysis on systems with different dataset names.";
-    }
-    if (duplicateSelectedSystemNames) {
-      disabled = true;
-      tooltipMessage =
-        "Cannot perform multiple system analysis on systems with the same names.";
-    }
-    analysisButton = (
-      <Button
-        disabled={disabled}
-        onClick={() => onActiveSystemChange(selectedSystemIDs)}
-      >
-        Multiple System Analysis
+        {selectedSystemIDs.length === 2
+          ? "Pairwise Analysis"
+          : "Multiple System Analysis"}
         {warning && <WarningOutlined />}
       </Button>
     );

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -43,15 +43,26 @@ export function SystemTableTools({
   selectedSystemIDs,
   onActiveSystemChange,
 }: Props) {
-  function findSelectedSystemDatasetNames() {
-    const selectedSystems = systems.filter((sys) =>
-      selectedSystemIDs.includes(sys.system_id)
-    );
+  console.log("selectedSystemIDs", selectedSystemIDs);
+  function findSelectedSystemDatasetNames(selectedSystems: SystemModel[]) {
     return new Set<string>(
       selectedSystems.map((sys) => sys.dataset?.dataset_name || "unspecified")
     );
   }
-  const selectedSystemDatasetNames = findSelectedSystemDatasetNames();
+  function hasDuplicateSelectedSystemNames(selectedSystems: SystemModel[]) {
+    const selectedSystemNames = selectedSystems.map((sys) => sys.system_name);
+    const distinctSystemNames = new Set(selectedSystemNames);
+    return distinctSystemNames.size !== selectedSystemNames.length
+      ? true
+      : false;
+  }
+  const selectedSystems = systems.filter((sys) =>
+    selectedSystemIDs.includes(sys.system_id)
+  );
+  const selectedSystemDatasetNames =
+    findSelectedSystemDatasetNames(selectedSystems);
+  const duplicateSelectedSystemNames =
+    hasDuplicateSelectedSystemNames(selectedSystems);
 
   // Deleted Selected Systems
   async function deleteSystems(systemIDs: string[]) {
@@ -139,6 +150,11 @@ export function SystemTableTools({
       tooltipMessage =
         "Cannot perform multiple system analysis on systems with different dataset names.";
     }
+    if (duplicateSelectedSystemNames) {
+      disabled = true;
+      tooltipMessage =
+        "Cannot perform multiple system analysis on systems with the same names.";
+    }
     analysisButton = (
       <Button
         disabled={disabled}
@@ -166,6 +182,11 @@ export function SystemTableTools({
       disabled = true;
       tooltipMessage =
         "Cannot perform multiple analysis on systems with different dataset names.";
+    }
+    if (duplicateSelectedSystemNames) {
+      disabled = true;
+      tooltipMessage =
+        "Cannot perform multiple system analysis on systems with the same names.";
     }
     analysisButton = (
       <Button

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -43,23 +43,15 @@ export function SystemTableTools({
   selectedSystemIDs,
   onActiveSystemChange,
 }: Props) {
-  function findSelectedSystemDatasetNames(selectedSystems: SystemModel[]) {
+  function findSelectedSystemDatasetNames() {
+    const selectedSystems = systems.filter((sys) =>
+      selectedSystemIDs.includes(sys.system_id)
+    );
     return new Set<string>(
       selectedSystems.map((sys) => sys.dataset?.dataset_name || "unspecified")
     );
   }
-  function hasDuplicateSelectedSystemNames(selectedSystems: SystemModel[]) {
-    const selectedSystemNames = selectedSystems.map((sys) => sys.system_name);
-    const distinctSystemNames = new Set(selectedSystemNames);
-    return distinctSystemNames.size !== selectedSystemNames.length;
-  }
-  const selectedSystems = systems.filter((sys) =>
-    selectedSystemIDs.includes(sys.system_id)
-  );
-  const selectedSystemDatasetNames =
-    findSelectedSystemDatasetNames(selectedSystems);
-  const duplicateSelectedSystemNames =
-    hasDuplicateSelectedSystemNames(selectedSystems);
+  const selectedSystemDatasetNames = findSelectedSystemDatasetNames();
 
   // Deleted Selected Systems
   async function deleteSystems(systemIDs: string[]) {
@@ -146,11 +138,6 @@ export function SystemTableTools({
       disabled = true;
       tooltipMessage =
         "Cannot perform multiple system analysis on systems with different dataset names.";
-    }
-    if (duplicateSelectedSystemNames) {
-      disabled = true;
-      tooltipMessage =
-        "Cannot perform multiple system analysis on systems with the same names.";
     }
     analysisButton = (
       <Button


### PR DESCRIPTION
This PR aims to fix Issue #426 10(a)

## Problem
When selecting systems with the same names and performing pairwise/multiple system analysis, the bar charts are in the same color and use one system name.
<img width="1436" alt="Screen Shot 2022-11-01 at 4 10 40 PM" src="https://user-images.githubusercontent.com/71625258/199332550-ac6b9152-2683-4da2-83fa-970a5e9d4888.png">

## Solution
Disable the analysis button when duplicate system names are detected.
<img width="1436" alt="Screen Shot 2022-11-01 at 4 11 59 PM" src="https://user-images.githubusercontent.com/71625258/199332716-0078bd17-5bdc-44fb-b297-0aa01a82ee22.png">
