### PR TITLE
fix browser nav back

### DIFF
--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -33,7 +33,7 @@ export function SystemsTable() {
     const prevString = query.toString();
     const newString = filters.toUrlParams().toString();
     if (prevString !== newString) {
-      history.push({ search: filters.toUrlParams().toString() });
+      history.replace({ search: filters.toUrlParams().toString() });
     }
   }, [history, filters, query]);
 


### PR DESCRIPTION
A simple fix for issue #476 

Now goes back to the previous page properly.

Do we expect nav back to cancel previous filter change instead of going back to the previous page? If that's the case, then I should probably change a few other things as well.

