### PR TITLE
fix: onBarClick() use the same cases for different systems

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -99,13 +99,14 @@ export function MetricPane(props: Props) {
         caseIDs: resultParsed.cases[barIndex],
       })
     );
+    const selectedLevelAndCaseIDs = levelAndCaseIDs[systemIndex];
     try {
       let caseDetails = await Promise.all(
-        levelAndCaseIDs.map(({ levelName, caseIDs }, i) =>
+        systems.map((sys) =>
           backendClient.systemCasesGetById(
-            systems[i].system_id,
-            levelName,
-            caseIDs
+            sys.system_id,
+            selectedLevelAndCaseIDs.levelName,
+            selectedLevelAndCaseIDs.caseIDs
           )
         )
       );


### PR DESCRIPTION
Closes #482 

For each (systemIdx, barIdx) tuple, the cases used to display for all systems should be based on the system clicked. 

For example, imagine this scenario where there is a blue(sys1) and a green bar(sys2) side-by-side.
```
"length of the source": 3-14 
blue bar -> system 1 caseIDs: [1, 3, 5] 
green bar -> system 2 caseIDs: [2, 4, 6]
```
When we click on the blue bar, we expect to see the model predictions for caseIDs 1, 3, 5 for all systems.
Likewise, when we click on the green bar, we expect to see the model predictions for caseIDs 2, 4, 6 for all systems.