### PR TITLE
store `metric_names` in the DB

### DIFF
--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -286,7 +286,10 @@ class SystemDBUtils:
             def db_operations(session: ClientSession) -> None:
                 system.save_to_db(session)
                 system.save_system_output(system_output_data, session)
-                system.update_overall_statistics(metadata, system_output_data, session)
+                try:
+                    system.update_overall_statistics(system_output_data, session)
+                except ValueError as e:
+                    abort_with_error_message(400, str(e))
 
             DBUtils.execute_transaction(db_operations)
             return system

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -21,7 +21,6 @@ from explainaboard_web.impl.utils import (
 )
 from explainaboard_web.models.system import System
 from explainaboard_web.models.system_info import SystemInfo
-from explainaboard_web.models.system_metadata import SystemMetadata
 from pymongo.client_session import ClientSession
 
 
@@ -149,7 +148,6 @@ class SystemModel(System):
 
     def update_overall_statistics(
         self,
-        metadata: SystemMetadata,
         system_output_data: FileLoaderReturn,
         session: ClientSession | None = None,
         force_update=False,
@@ -168,11 +166,9 @@ class SystemModel(System):
                 for metric in get_processor(self.task).full_metric_list()
             }
             metric_configs: list[MetricConfig] = []
-            for metric_name in metadata.metric_names:
+            for metric_name in self.metric_names:
                 if metric_name not in metrics_lookup:
-                    abort_with_error_message(
-                        400, f"{metric_name} is not a supported metric"
-                    )
+                    raise ValueError(f"{metric_name} is not a supported metric")
                 metric_configs.append(metrics_lookup[metric_name])
             custom_features = system_output_data.metadata.custom_features or {}
             custom_features.update(self.get_dataset_custom_features())

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.11"
+  version: "0.2.12"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -972,6 +972,14 @@ components:
               description: the user who created the system
             preferred_username:
               type: string
+            metric_names:
+              description: >
+                metric_names selected when the system is created. It is the same as
+                the metric_names field in SystemMetadata.
+              type: array
+              items:
+                type: string
+              example: [Accuracy, F1]
             results:
               type: object
               example: {"span": {"F1": 0.9221}}
@@ -1013,6 +1021,7 @@ components:
             - source_language
             - target_language
             - task
+            - metric_names
             - results
         - $ref: "#/components/schemas/Time"
 


### PR DESCRIPTION
blocked by #491 
part of #433 
Stores `metric_names` in the DB because it is required when we use `update_overall_statistics()` to update the analysis. `update_overall_statistics()` does not depend on `metadata` anymore. It still depends on `system_output_data` though. I will remove that dependency in the next PR.

### Compatibility
- DB migration required
- A new field is added to the returned `System` model. This is compatible with old versions of `explainaboard_api_client` so it shouldn't break anything. I tested `explainaboard_api_client=0.2.11` (which is the oldest version we support) with this code and it worked OK.