### PR TITLE
Add Metric Description in System Submit Drawer Page

### DIFF
--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -631,7 +631,7 @@ export function SystemSubmitDrawer(props: Props) {
             label="Metrics"
             tooltip="The metrics that are used to evaluate each system."
             hidden={editMode}
-            required={true}
+            required
           >
             <Space size="small">
               <Form.Item

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -33,6 +33,7 @@ import { SystemModel } from "../../models";
 import "./index.css";
 
 const { TextArea } = Input;
+const { Text, Link } = Typography;
 
 interface Props extends DrawerProps {
   systemToEdit?: SystemModel;
@@ -629,6 +630,7 @@ export function SystemSubmitDrawer(props: Props) {
           <Form.Item
             label="Metrics"
             name="metric_names"
+            tooltip="The metrics that are used to evaluate each system."
             rules={editMode ? [] : [{ required: true }]}
             hidden={editMode}
           >
@@ -644,12 +646,16 @@ export function SystemSubmitDrawer(props: Props) {
                   )}
                 />
               </Form.Item>
-              <Typography.Link
-                target="_blank"
-                href="https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md"
-              >
-                Metric Description
-              </Typography.Link>
+              <Text>
+                <Link
+                  target="_blank"
+                  href="https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md"
+                >
+                  Click here&nbsp;
+                </Link>
+                to see a list of metrics supported for each task, along with
+                detailed descriptions.
+              </Text>
             </Space>
           </Form.Item>
 

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -633,7 +633,7 @@ export function SystemSubmitDrawer(props: Props) {
             rules={editMode ? [] : [{ required: true }]}
             hidden={editMode}
           >
-            <Space size={"small"}>
+            <Space size="small">
               <Form.Item noStyle name="metric_names">
                 <Select
                   style={{ width: 300 }}

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -629,13 +629,12 @@ export function SystemSubmitDrawer(props: Props) {
 
           <Form.Item
             label="Metrics"
-            name="metric_names"
             tooltip="The metrics that are used to evaluate each system."
             rules={editMode ? [] : [{ required: true }]}
             hidden={editMode}
           >
             <Space size={"small"}>
-              <Form.Item noStyle>
+              <Form.Item noStyle name="metric_names">
                 <Select
                   style={{ width: 300 }}
                   mode="multiple"

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -626,16 +626,16 @@ export function SystemSubmitDrawer(props: Props) {
             />
           </Form.Item>
 
-          <Row>
-            <Col span={4}>&nbsp;</Col>
-            <Col span={10}>
-              <Form.Item
-                name="metric_names"
-                label="Metrics"
-                rules={editMode ? [] : [{ required: true }]}
-                hidden={editMode}
-              >
+          <Form.Item
+            label="Metrics"
+            name="metric_names"
+            rules={editMode ? [] : [{ required: true }]}
+            hidden={editMode}
+          >
+            <Space size={"small"}>
+              <Form.Item noStyle>
                 <Select
+                  style={{ width: 300 }}
                   mode="multiple"
                   options={(selectedTask?.supported_metrics || []).map(
                     (opt) => ({
@@ -644,16 +644,14 @@ export function SystemSubmitDrawer(props: Props) {
                   )}
                 />
               </Form.Item>
-            </Col>
-            <Col span={10}>
               <Typography.Link
+                target="_blank"
                 href="https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md"
-                style={{ marginLeft: 8 }}
               >
                 Metric Description
               </Typography.Link>
-            </Col>
-          </Row>
+            </Space>
+          </Form.Item>
 
           <Form.Item
             name="is_private"

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -630,11 +630,15 @@ export function SystemSubmitDrawer(props: Props) {
           <Form.Item
             label="Metrics"
             tooltip="The metrics that are used to evaluate each system."
-            rules={editMode ? [] : [{ required: true }]}
             hidden={editMode}
+            required={true}
           >
             <Space size="small">
-              <Form.Item noStyle name="metric_names">
+              <Form.Item
+                noStyle
+                name="metric_names"
+                rules={editMode ? [] : [{ required: true }]}
+              >
                 <Select
                   style={{ width: 300 }}
                   mode="multiple"

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -647,7 +647,7 @@ export function SystemSubmitDrawer(props: Props) {
             </Col>
             <Col span={10}>
               <Typography.Link
-                href="https://github.com/neulab/ExplainaBoard/docs/supported_metrics.md"
+                href="https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md"
                 style={{ marginLeft: 8 }}
               >
                 Metric Description

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -13,6 +13,7 @@ import {
   Checkbox,
   Row,
   Col,
+  Typography,
 } from "antd";
 import {
   DatasetMetadata,
@@ -625,19 +626,34 @@ export function SystemSubmitDrawer(props: Props) {
             />
           </Form.Item>
 
-          <Form.Item
-            name="metric_names"
-            label="Metrics"
-            rules={editMode ? [] : [{ required: true }]}
-            hidden={editMode}
-          >
-            <Select
-              mode="multiple"
-              options={(selectedTask?.supported_metrics || []).map((opt) => ({
-                value: opt,
-              }))}
-            />
-          </Form.Item>
+          <Row>
+            <Col span={4}>&nbsp;</Col>
+            <Col span={10}>
+              <Form.Item
+                name="metric_names"
+                label="Metrics"
+                rules={editMode ? [] : [{ required: true }]}
+                hidden={editMode}
+              >
+                <Select
+                  mode="multiple"
+                  options={(selectedTask?.supported_metrics || []).map(
+                    (opt) => ({
+                      value: opt,
+                    })
+                  )}
+                />
+              </Form.Item>
+            </Col>
+            <Col span={10}>
+              <Typography.Link
+                href="https://github.com/neulab/ExplainaBoard/docs/supported_metrics.md"
+                style={{ marginLeft: 8 }}
+              >
+                Metric Description
+              </Typography.Link>
+            </Col>
+          </Row>
 
           <Form.Item
             name="is_private"


### PR DESCRIPTION
This PR adds Metric Description link in system submit drawer page.
This is part of #426 UI Optimization plan, bullet point number 14.

> 14.They (test users) were not familiar with some of the metrics. They would love to have more explanations (e.g. what is lexical diversity). (proposed by Ying)

### The New Look
- The metric selection dropdown is now smaller
- added hyperlink to ExplainaBoard `supported_metrics.md` document
<img width="758" alt="截圖 2022-11-06 上午8 57 30" src="https://user-images.githubusercontent.com/36850051/200174946-2dac1d3d-fc5a-42c5-bfce-5581d1b27a14.png">


### Next Steps
I will add link to metric description in the Analysis page as well.