### PR TITLE
Add metric description link in analysis drawer

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Drawer, Spin, Tooltip } from "antd";
+import { Button, Drawer, Space, Spin, Tooltip } from "antd";
 import { SystemModel } from "../../../models";
 import { ErrorBoundary, AnalysisReport } from "../../../components";
 import { PageState } from "../../../utils";
@@ -261,10 +261,19 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
       closable={pageState !== PageState.loading}
       maskClosable={pageState !== PageState.loading}
       extra={
-        <AnalysisButton
-          disabled={!bucketInfoUpdated}
-          onClick={() => setShouldUpdateAnalysis(true)}
-        />
+        <Space>
+          <Button
+            type="link"
+            target="_blank"
+            href="https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md"
+          >
+            Metric Description
+          </Button>
+          <AnalysisButton
+            disabled={!bucketInfoUpdated}
+            onClick={() => setShouldUpdateAnalysis(true)}
+          />
+        </Space>
       }
     >
       {/* The analysis report is expected to fail if a user selects systems with different datasets.


### PR DESCRIPTION
This PR is related to #426 UI Optimization bullet point number 14.

> 14.They (test users) were not familiar with some of the metrics. They would love to have more explanations (e.g. what is lexical diversity). (proposed by Ying)

### Changes
- add "Metric Description" link on the Analysis Drawer page
- this button directs to https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md on a new tab

### The New Look
<img width="1278" alt="截圖 2022-11-07 上午11 12 28" src="https://user-images.githubusercontent.com/36850051/200359483-bdf53aa4-f3d9-47db-b652-d3efe1a64a28.png">
