### PR TITLE
remove custom_features field from Dataset

### DIFF
--- a/backend/src/impl/db_utils/dataset_db_utils.py
+++ b/backend/src/impl/db_utils/dataset_db_utils.py
@@ -48,7 +48,6 @@ class DatasetDB:
                 "split": v_dataset["splits"],
                 "tasks": tasks,
                 "languages": v_dataset.get("languages"),
-                "custom_features": v_dataset.get("custom_features"),
             }
             self.metadatas.append(DatasetMetadata.from_dict(doc))
         self.name_trie = marisa_trie.Trie(self.name_dict.keys())

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -198,7 +198,6 @@ class SystemDBUtils:
                         system.dataset.dataset_name,
                         system.dataset.sub_dataset,
                         system.dataset.split,
-                        custom_features=system.get_dataset_custom_features(),
                     ),
                     output_data=system_output.data,
                     output_file_type=FileType(system_output.file_type),

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -11,7 +11,6 @@ from explainaboard import get_processor
 from explainaboard.loaders.file_loader import FileLoaderReturn
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.serialization.legacy import general_to_dict
-from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
 from explainaboard_web.impl.storage import get_storage
 from explainaboard_web.impl.utils import (
@@ -97,13 +96,6 @@ class SystemModel(System):
         properties = self._get_private_properties()
         return [[unbinarize_bson(y) for y in x] for x in properties["metric_stats"]]
 
-    def get_dataset_custom_features(self) -> dict:
-        if self.dataset:
-            dataset_info = DatasetDBUtils.find_dataset_by_id(self.dataset.dataset_id)
-            if dataset_info and dataset_info.custom_features:
-                return dict(dataset_info.custom_features)
-        return {}
-
     def save_to_db(self, session: ClientSession | None = None) -> None:
         """creates a new record if not exist, otherwise update
         TODO(lyuyang): implement update
@@ -171,8 +163,6 @@ class SystemModel(System):
                     raise ValueError(f"{metric_name} is not a supported metric")
                 metric_configs.append(metrics_lookup[metric_name])
             system_output_metadata: dict = properties.get("system_output_metadata", {})
-            custom_features = system_output_metadata.get("custom_features") or {}
-            custom_features.update(self.get_dataset_custom_features())
             processor_metadata = {
                 # system properties
                 "system_name": self.system_name,
@@ -185,7 +175,7 @@ class SystemModel(System):
                 "system_details": self.system_details,
                 # processor parameters
                 "metric_configs": metric_configs,
-                "custom_features": custom_features,
+                "custom_features": system_output_metadata.get("custom_features") or {},
                 "custom_analyses": system_output_metadata.get("custom_analyses") or [],
             }
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.13"
+  version: "0.2.14"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -1102,8 +1102,6 @@ components:
         huggingface_link:
           type: string
           format: url
-        custom_features:
-          type: object
       required:
         - dataset_id
         - dataset_name


### PR DESCRIPTION
- [dataset_info.jsonl](https://raw.githubusercontent.com/ExpressAI/DataLab/main/utils/dataset_info.jsonl) does not include `custom_features`
- `custom_features` and `custom_analyses` from the datasets are added to the system by the SDK ([relevant code](https://github.com/neulab/ExplainaBoard/blob/a0187c0efb8fe5febd868885e139849a678d34fc/explainaboard/loaders/file_loader.py#L648)) so `explainaboard_web` does not need to handle it. We only need to handle `custom_features` and `custom_analyses` provided by the user (from the system output file) in this repo.