### PR TITLE
download example table in xlsx

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-helmet": "^6.1.5",
         "@types/react-router-dom": "^5.3.0",
         "antd": "^4.17.0",
+        "antd-table-export": "^0.0.5",
         "echarts": "^5.3.3",
         "echarts-for-react": "^3.0.2",
         "eslint": "^7.32.0",
@@ -4394,6 +4395,21 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
+      "dependencies": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      },
+      "bin": {
+        "adler32": "bin/adler32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -4580,6 +4596,14 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/antd-table-export": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/antd-table-export/-/antd-table-export-0.0.5.tgz",
+      "integrity": "sha512-zc+BhIywfjdfVHT7+NaD//gFO4VP+y4hqtN5cwMdUGcOfcCw/RZ6R89qHbRhaHAGOOmgddul0bXA4+XkP7AYJw==",
+      "dependencies": {
+        "xlsx": "^0.17.1"
       }
     },
     "node_modules/antd/node_modules/rc-cascader": {
@@ -6487,6 +6511,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cfb/node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6747,6 +6791,14 @@
       },
       "engines": {
         "node": ">= 4.0"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -7109,6 +7161,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-ecdh": {
@@ -9728,6 +9791,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -10455,6 +10526,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fragment-cache": {
@@ -18458,6 +18537,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "bin": {
+        "printj": "bin/printj.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -21518,6 +21608,17 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -24560,6 +24661,22 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -24902,6 +25019,26 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.5.tgz",
+      "integrity": "sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==",
+      "dependencies": {
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.0",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -28234,6 +28371,15 @@
         "regex-parser": "^2.2.11"
       }
     },
+    "adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -28573,6 +28719,14 @@
             "shallowequal": "^1.1.0"
           }
         }
+      }
+    },
+    "antd-table-export": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/antd-table-export/-/antd-table-export-0.0.5.tgz",
+      "integrity": "sha512-zc+BhIywfjdfVHT7+NaD//gFO4VP+y4hqtN5cwMdUGcOfcCw/RZ6R89qHbRhaHAGOOmgddul0bXA4+XkP7AYJw==",
+      "requires": {
+        "xlsx": "^0.17.1"
       }
     },
     "anymatch": {
@@ -29900,6 +30054,22 @@
       "integrity": "sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==",
       "dev": true
     },
+    "cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "requires": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "dependencies": {
+        "adler-32": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+          "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
+        }
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -30107,6 +30277,11 @@
         "chalk": "^2.4.1",
         "q": "^1.1.2"
       }
+    },
+    "codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -30414,6 +30589,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -32433,6 +32613,11 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -33038,6 +33223,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
+    },
+    "frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -39277,6 +39467,11 @@
         }
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -41738,6 +41933,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "requires": {
+        "frac": "~1.1.2"
+      }
+    },
     "ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -44182,6 +44385,16 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
+    },
+    "word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -44482,6 +44695,20 @@
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "requires": {}
+    },
+    "xlsx": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.5.tgz",
+      "integrity": "sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==",
+      "requires": {
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.0",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      }
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@types/react-helmet": "^6.1.5",
     "@types/react-router-dom": "^5.3.0",
     "antd": "^4.17.0",
+    "antd-table-export": "^0.0.5",
     "echarts": "^5.3.3",
     "echarts-for-react": "^3.0.2",
     "eslint": "^7.32.0",

--- a/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/ExampleTable.tsx
@@ -71,6 +71,7 @@ export function ExampleTable({
     // all single analysis cases + multi-system analysis for tasks with column info
     exampleTable = (
       <AnalysisTable
+        tableTitle={title}
         systemIDs={systemIDs}
         systemNames={systemNames}
         task={task}
@@ -90,6 +91,7 @@ export function ExampleTable({
             return (
               <Tabs.TabPane tab={system.system_name} key={`${sysIndex}`}>
                 <AnalysisTable
+                  tableTitle={title}
                   systemIDs={systemIDsArray[sysIndex]}
                   systemNames={[system.system_name]}
                   task={task}

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
-import { message, Table, Tooltip, Typography } from "antd";
+import { Button, message, Table, Tooltip, Typography } from "antd";
+import tableExport from "antd-table-export";
 import { ColumnsType } from "antd/lib/table";
 import { AnalysisCase, SystemOutput } from "../../../clients/openapi";
 import { backendClient, parseBackendError } from "../../../clients";
@@ -9,8 +10,10 @@ import {
   seqLabTasks,
 } from "../AnalysisTable/taskColumnMapping";
 import { addPredictionColInfo, unnestAnalysisCases } from "./utils";
+import { DownloadOutlined } from "@ant-design/icons";
 
 interface Props {
+  tableTitle: string;
   systemIDs: string[];
   systemNames: string[];
   task: string;
@@ -171,6 +174,7 @@ function specifyDataSeqLab(
 }
 
 export function AnalysisTable({
+  tableTitle,
   systemIDs,
   systemNames,
   task,
@@ -238,55 +242,83 @@ export function AnalysisTable({
   }
 
   const columns: ColumnsType<SystemOutput> = [];
-  let dataSource: { [p: string]: string }[];
-  let colInfo;
+  const casesThisPage = cases.slice(offset, end);
   const numSystems = systemIDs.length;
   const taskCols = taskColumnMapping.get(task);
-  const casesThisPage = cases.slice(offset, end);
-  if (seqLabTasks.includes(task)) {
-    dataSource = specifyDataSeqLab(systemOutputs, casesThisPage, columns);
-  } else if (taskCols !== undefined) {
-    colInfo = addPredictionColInfo(task, systemNames);
-    /* expand columns if it is multi-system analysis */
-    if (numSystems > 1) {
-      dataSource = specifyDataGeneric(
-        unnestAnalysisCases(casesThisPage, taskCols.predictionColumns[0].id),
-        columns,
-        colInfo
-      );
+  function getDataSourceAndColumns(
+    caseSource: AnalysisCase[],
+    columns: ColumnsType<SystemOutput>
+  ) {
+    let dataSource: { [p: string]: string }[];
+    let colInfo;
+    if (seqLabTasks.includes(task)) {
+      dataSource = specifyDataSeqLab(systemOutputs, caseSource, columns);
+    } else if (taskCols !== undefined) {
+      colInfo = addPredictionColInfo(task, systemNames);
+      /* expand columns if it is multi-system analysis */
+      if (numSystems > 1) {
+        dataSource = specifyDataGeneric(
+          unnestAnalysisCases(caseSource, taskCols.predictionColumns[0].id),
+          columns,
+          colInfo
+        );
+      } else {
+        dataSource = specifyDataGeneric(caseSource, columns, colInfo);
+      }
     } else {
-      dataSource = specifyDataGeneric(casesThisPage, columns, colInfo);
+      dataSource = specifyDataGeneric(caseSource, columns);
     }
-  } else {
-    dataSource = specifyDataGeneric(casesThisPage, columns);
-  }
 
-  // add id to dataSource
-  for (let i = 0; i < dataSource.length; i++) {
-    for (const [key, value] of Object.entries(dataSource[i])) {
-      if (key === "sample_id") {
-        dataSource[i]["id"] = value;
+    // add id to dataSource
+    for (let i = 0; i < dataSource.length; i++) {
+      for (const [key, value] of Object.entries(dataSource[i])) {
+        if (key === "sample_id") {
+          dataSource[i]["id"] = value;
+        }
       }
     }
+    return dataSource;
+  }
+  const dataSource: { [p: string]: string }[] = getDataSourceAndColumns(
+    casesThisPage,
+    columns
+  );
+
+  function downloadTable() {
+    const dowloadColumns: ColumnsType<SystemOutput> = [];
+    const totalDataSource: { [p: string]: string }[] = getDataSourceAndColumns(
+      cases,
+      dowloadColumns
+    );
+    const exportColumns = dowloadColumns.map((col: SystemOutput) => {
+      return { dataIndex: col.dataIndex, title: col.title };
+    });
+    const exportInstance = new tableExport(totalDataSource, exportColumns);
+    exportInstance.download(tableTitle);
   }
 
   return (
-    <Table
-      ref={tableRef}
-      columns={columns}
-      dataSource={dataSource}
-      rowKey="id"
-      size="small"
-      pagination={{
-        total,
-        showTotal: (total, range) =>
-          `${range[0]}-${range[1]} (total: ${total})`,
-        pageSize,
-        // conversion between 0-based and 1-based index
-        current: page + 1,
-        onChange: (newPage) => setPage(newPage - 1),
-      }}
-      scroll={{ y: 550, x: "max-content", scrollToFirstRowOnChange: true }}
-    />
+    <div>
+      <Button icon={<DownloadOutlined />} onClick={downloadTable}>
+        Download
+      </Button>
+      <Table
+        ref={tableRef}
+        columns={columns}
+        dataSource={dataSource}
+        rowKey="id"
+        size="small"
+        pagination={{
+          total,
+          showTotal: (total, range) =>
+            `${range[0]}-${range[1]} (total: ${total})`,
+          pageSize,
+          // conversion between 0-based and 1-based index
+          current: page + 1,
+          onChange: (newPage) => setPage(newPage - 1),
+        }}
+        scroll={{ y: 550, x: "max-content", scrollToFirstRowOnChange: true }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
This PR is related to issue #503 

## Download example table of fine-grained analysis
* Add a download button above the table

<img width="1272" alt="Screen Shot 2022-11-12 at 6 31 42 PM" src="https://user-images.githubusercontent.com/71625258/201498715-62c9beb7-d8ce-412c-b93e-b1f559c0a68b.png">

* Download the entire table (page 1-5) into a xlsx file.

<img width="738" alt="Screen Shot 2022-11-12 at 6 32 07 PM" src="https://user-images.githubusercontent.com/71625258/201498749-927dab97-2896-4496-9ca7-0141d5e36750.png">

Note: the CSV format is not supported now because the react-csv package is not compatible with @type/react='^17.x' used in the frontend now. antd-table-export package only supports xlsx format.
