### PR TITLE
Example table copyable columns

### DIFF
--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -50,7 +50,7 @@ function renderColInfo(
         ) : (
           <Typography.Paragraph
             copyable
-            ellipsis={{ rows: 3, tooltip: true, expandable: true }}
+            ellipsis={{ rows: 3, tooltip: false, expandable: true }}
             style={{ marginBottom: 0, minWidth: "80px", maxWidth: maxWidth }}
           >
             {value}

--- a/frontend/src/components/Analysis/AnalysisTable/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisTable/index.tsx
@@ -28,7 +28,7 @@ function renderColInfo(
     title: "ID",
     fixed: "left",
     render: (value) => (
-      <Typography.Paragraph copyable style={{ marginBottom: 0 }}>
+      <Typography.Paragraph style={{ marginBottom: 0 }}>
         {value}
       </Typography.Paragraph>
     ),
@@ -49,6 +49,7 @@ function renderColInfo(
           </div>
         ) : (
           <Typography.Paragraph
+            copyable
             ellipsis={{ rows: 3, tooltip: true, expandable: true }}
             style={{ marginBottom: 0, minWidth: "80px", maxWidth: maxWidth }}
           >


### PR DESCRIPTION
This PR is related to issue #503 

Change the copy function of the example table: ID is changed to non-copyable and the other columns are copyable.
E.g. Text classification

<img width="1242" alt="Screen Shot 2022-11-13 at 12 04 11 AM" src="https://user-images.githubusercontent.com/71625258/201506850-a9cccebd-f1c7-4ea5-b013-d44e0a8cff68.png">

E.g. Conditional generation

<img width="1264" alt="Screen Shot 2022-11-13 at 12 03 45 AM" src="https://user-images.githubusercontent.com/71625258/201506853-ec4a6252-1545-4bdd-b435-35aefae35a46.png">
