### PR TITLE
flask template: put requiredVars before optionalVars

### DIFF
--- a/backend/templates/model.mustache
+++ b/backend/templates/model.mustache
@@ -38,7 +38,7 @@ class {{classname}}(Model):
     {{/vars}}
     }
 
-    def __init__(self{{#vars}}, {{name}}{{^supportPython2}}: {{datatype}}{{^required}} | None{{/required}}{{/supportPython2}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{^required}} = None{{/required}}{{/defaultValue}}{{/vars}}):  # noqa: E501
+    def __init__(self{{#requiredVars}}, {{name}}: {{datatype}}{{/requiredVars}}{{#optionalVars}}, {{name}}: {{datatype}} {{#defaultValue}}= {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}| None = None{{/defaultValue}}{{/optionalVars}}):  # noqa: E501
         """{{classname}} - a model defined in Swagger
 
         {{#vars}}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -877,7 +877,6 @@ components:
           description: a place to store arbitrary system details you want to remember
         is_private:
           type: boolean
-          default: true
         shared_users:
           type: array
           items:
@@ -911,7 +910,6 @@ components:
           example: en
         is_private:
           type: boolean
-          default: true
         shared_users:
           type: array
           items:


### PR DESCRIPTION
followup of #395. `requiredVars` now always come before `optionalVars` so there is no need to manually order the properties in `openapi.yaml`. This also solves the issue mentioned in #509.

- I removed `supportPython2` because we don't need to support py2.
- I removed two default values in `openapi.yaml`. I don't think those default values do anything. Those two properties are required so they should not have a default value (the user needs to explicitly provide a value).