### PR TITLE
fix analysis button

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -92,34 +92,37 @@ export function SystemTableTools({
     );
   }
 
-  let analysisButton = (
-    <Tooltip
-      title={
-        <div>
-          <p>Single Analysis: Click the Analysis button on any system row.</p>
-          <p>
-            Pairwise Analysis: Select two systems that use the same dataset. A
-            Pairwise Analysis button will appear at the top. The dataset name
-            can be unspecified, but proceed with caution.
-          </p>
-          <p>
-            Multi-system Analysis: Select multiple system that use the same
-            dataset.
-          </p>
-        </div>
-      }
-      placement="bottom"
-      color="white"
-      overlayInnerStyle={{ color: "black" }}
-    >
-      <Button type="link" size="small" style={{ padding: 0 }}>
-        What kind of analysis is supported?
-      </Button>
-    </Tooltip>
-  );
+  let analysisButton;
 
+  if (selectedSystemIDs.length === 0) {
+    analysisButton = (
+      <Tooltip
+        title={
+          <div>
+            <p>Single Analysis: Click the Analysis button on any system row.</p>
+            <p>
+              Pairwise Analysis: Select two systems that use the same dataset. A
+              Pairwise Analysis button will appear at the top. The dataset name
+              can be unspecified, but proceed with caution.
+            </p>
+            <p>
+              Multi-system Analysis: Select multiple system that use the same
+              dataset.
+            </p>
+          </div>
+        }
+        placement="bottom"
+        color="white"
+        overlayInnerStyle={{ color: "black" }}
+      >
+        <Button type="link" size="small" style={{ padding: 0 }}>
+          What kind of analysis is supported?
+        </Button>
+      </Tooltip>
+    );
+  }
   // Single analysis
-  if (selectedSystemIDs.length === 1) {
+  else if (selectedSystemIDs.length === 1) {
     analysisButton = (
       <Button onClick={() => onActiveSystemChange(selectedSystemIDs)}>
         Analysis


### PR DESCRIPTION
Fix analysis button error due to the code refactoring in PR #478 . 

Error: the analysis button displays "Multiple System Analysis" when no systems are selected.

<img width="576" alt="Screen Shot 2022-11-15 at 4 10 17 PM" src="https://user-images.githubusercontent.com/71625258/202027296-8c0301b5-30ce-4416-829a-c06d10465687.png">

Fix:

<img width="663" alt="Screen Shot 2022-11-15 at 4 19 46 PM" src="https://user-images.githubusercontent.com/71625258/202027585-d048b8fa-5081-4c54-85b3-84fc3bc9f749.png">
