### PR TITLE
Add metric descriptions to backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         entry: flake8
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git
-    rev: 5.10.1
+    rev: 5.6.4
     hooks:
       - id: isort
         files: '\.py$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         entry: flake8
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
       - id: isort
         files: '\.py$'
@@ -27,7 +27,7 @@ repos:
         files: '\.py$'
         args: ["--py39-plus"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.982'
+    rev: "v0.982"
     hooks:
       - id: mypy
         additional_dependencies:

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -59,6 +59,7 @@ from flask import current_app
 from pymongo import ASCENDING, DESCENDING
 from pymongo.client_session import ClientSession
 
+
 def _is_creator(system: System, user: authUser) -> bool:
     """check if a user is the creator of a system"""
     return system.creator == user.id

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -17,7 +17,6 @@ from explainaboard.metrics.metric import SimpleMetricStats
 from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.typing_utils import narrow
-
 from explainaboard_web.impl.analyses.significance_analysis import (
     pairwise_significance_test,
 )

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -17,9 +17,6 @@ from explainaboard.metrics.metric import SimpleMetricStats
 from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.typing_utils import narrow
-from flask import current_app
-from pymongo import ASCENDING, DESCENDING
-from pymongo.client_session import ClientSession
 
 from explainaboard_web.impl.analyses.significance_analysis import (
     pairwise_significance_test,
@@ -58,7 +55,9 @@ from explainaboard_web.models import (
     TaskCategory,
 )
 from explainaboard_web.models import User as modelUser
-
+from flask import current_app
+from pymongo import ASCENDING, DESCENDING
+from pymongo.client_session import ClientSession
 
 def _is_creator(system: System, user: authUser) -> bool:
     """check if a user is the creator of a system"""

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -17,6 +17,10 @@ from explainaboard.metrics.metric import SimpleMetricStats
 from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.typing_utils import narrow
+from flask import current_app
+from pymongo import ASCENDING, DESCENDING
+from pymongo.client_session import ClientSession
+
 from explainaboard_web.impl.analyses.significance_analysis import (
     pairwise_significance_test,
 )
@@ -27,6 +31,7 @@ from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
 from explainaboard_web.impl.db_utils.system_db_utils import SystemDBUtils
 from explainaboard_web.impl.language_code import get_language_codes
+from explainaboard_web.impl.metric_descriptions import get_metric_descriptions
 from explainaboard_web.impl.private_dataset import is_private_dataset
 from explainaboard_web.impl.tasks import get_task_categories
 from explainaboard_web.impl.utils import (
@@ -53,9 +58,6 @@ from explainaboard_web.models.systems_return import SystemsReturn
 from explainaboard_web.models.task import Task
 from explainaboard_web.models.task_category import TaskCategory
 from explainaboard_web.models.user import User as modelUser
-from flask import current_app
-from pymongo import ASCENDING, DESCENDING
-from pymongo.client_session import ClientSession
 
 
 def _is_creator(system: System, user: authUser) -> bool:
@@ -168,6 +170,13 @@ def datasets_get(
         dataset_name=dataset_name,
         task=task,
     )
+
+
+""" /metricdescriptions """
+
+
+def metric_descriptions_get() -> dict[str, str]:
+    return get_metric_descriptions()
 
 
 """ /benchmarks """

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -43,21 +43,21 @@ from explainaboard_web.models import (
     Benchmark,
     BenchmarkConfig,
     DatasetMetadata,
+    DatasetsReturn,
+    LanguageCode,
     SingleAnalysis,
+    System,
+    SystemAnalysesReturn,
+    SystemCreateProps,
+    SystemInfo,
     SystemOutput,
+    SystemsAnalysesBody,
+    SystemsReturn,
+    SystemUpdateProps,
+    Task,
+    TaskCategory,
 )
-from explainaboard_web.models.datasets_return import DatasetsReturn
-from explainaboard_web.models.language_code import LanguageCode
-from explainaboard_web.models.system import System
-from explainaboard_web.models.system_analyses_return import SystemAnalysesReturn
-from explainaboard_web.models.system_create_props import SystemCreateProps
-from explainaboard_web.models.system_info import SystemInfo
-from explainaboard_web.models.system_update_props import SystemUpdateProps
-from explainaboard_web.models.systems_analyses_body import SystemsAnalysesBody
-from explainaboard_web.models.systems_return import SystemsReturn
-from explainaboard_web.models.task import Task
-from explainaboard_web.models.task_category import TaskCategory
-from explainaboard_web.models.user import User as modelUser
+from explainaboard_web.models import User as modelUser
 
 
 def _is_creator(system: System, user: authUser) -> bool:

--- a/backend/src/impl/metric_descriptions.py
+++ b/backend/src/impl/metric_descriptions.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+_metric_to_descriptions = {
+    "rouge1": "ROUGE-1 refers to the overlap of unigram (each word) between the"
+    " system and reference summaries.",
+    "rouge2": "ROUGE-2 refers to the overlap of bigrams between the system and"
+    " reference summaries.",
+    "rougeL": "ROUGE-L refers to the longest common subsequence between the "
+    "system and reference summaries.",
+    "prism_qe": "PRISM for quality estimation. It calculates Score(hypothesis| "
+    "source)",
+    "prism": "PRISM is a sequence to sequence framework trained from scratch. "
+    "prism calculates the average generation score of Score(hypothesis|"
+    "reference) and Score(reference|hypothesis).",
+    "mover_score": "MoverScore is a metric similar to BERTScore. Different from "
+    "BERTScore, it uses the Earth Mover’s Distance instead of the Euclidean Distance.",
+    "comet_qe": "COMET for quality estimation. comet_qe uses the "
+    "wmt20-comet-qe-da checkpoint which utilizes only source and hypothesis.",
+    "comet": "COMET is a neural framework for training multilingual machine "
+    "translation evaluation models. comet uses the wmt20-comet-da checkpoint"
+    " which utilizes source, hypothesis and reference.",
+    "chrf": "CHRF measures the character-level ngram matches between hypothesis "
+    "and reference.",
+    "bleu": "BLEU measures modified ngram matches between each candidate "
+    "translation and the reference translations.",
+    "bert_score_f": "BERTScore f score.",
+    "bert_score_r": "BERTScore recall.",
+    "bert_score_p": "BERTScore is a metric designed for evaluating translated "
+    "text using BERT-based matching framework. bert_score_p calculates the "
+    "BERTScore precision.",
+    "bart_score_en_src": "BARTScore using the CNNDM finetuned BART. It "
+    "calculates Score(hypothesis|source).",
+    "bart_score_en_ref": "BARTScore is a sequence to sequence framework based "
+    "on pre-trained language model BART.",
+    "bart_score_cnn_hypo_ref": "BARTScore using the CNNDM finetuned BART. It "
+    "calculates the average generation score of Score(hypothesis|reference) "
+    "and Score(reference|hypothesis).",
+    "bart_score_summ": "BARTScore is a sequence to sequence framework based on "
+    "pre-trained language model BART. For this metric, BART is finetuned on the "
+    "summarization data: CNN-Dailymail. It calculates the average generation "
+    "score of Score(hypothesis|reference) and Score(reference|hypothesis).",
+    "bart_score_mt": "BARTScore is a sequence to sequence framework based on "
+    "pre-trained language model BART. For this metric, BART is finetuned on the "
+    "paraphrase data: ParaBank. It calculates the average generation score of "
+    "Score(hypothesis|reference) and Score(reference|hypothesis).",
+    "length": "The length of generated text.",
+    "length_ratio": "The ratio between the length of generated text and gold reference",
+    "Accuracy": "Percentage of all correctly classified samples",
+    "F1": "Harmonic mean of precision and recall",
+    "CorrectCount": "The number of correctly predicted (e.g., classified) samples",
+    "Hits1": "It is the count of how many positive samples are ranked in the "
+    "top-1 positions against a bunch of negatives.",
+    "Hits2": "It is the count of how many positive samples are ranked in the "
+    "top-2 positions against a bunch of negatives.",
+    "Hits3": "It is the count of how many positive samples are ranked in the "
+    "top-3 positions against a bunch of negatives.",
+    "Hits4": "It is the count of how many positive samples are ranked in the "
+    "top-4 positions against a bunch of negatives.",
+    "Hits5": "It is the count of how many positive samples are ranked in the "
+    "top-5 positions against a bunch of negatives.",
+    "Hits10": "It is the count of how many positive samples are ranked in the "
+    "top-10 positions against a bunch of negatives.",
+    "MRR": "Mean Reciprocal Rank is a measure to evaluate systems that return "
+    "a ranked list of answers to queries.",
+    "MR": "The mean rank of the true output in a predicted n-best list",
+    "Perplexity": "Perplexity is a measurement of how well a probability "
+    "distribution or probability model predicts a sample.",
+    "LogProb": "A logarithm of a probability.",
+    "ExactMatch": "The Exact Match metric measures the percentage of "
+    "predictions that match any one of the ground truth answers exactly",
+    "LikertScore_fluency": "Human evaluation metric for the fluency of texts "
+    "with likert style",
+    "LikertScore_coherence": "Human evaluation metric for the coherence of "
+    "texts with likert style",
+    "LikertScore_factuality": "Human evaluation metric for the factuality of "
+    "texts with likert style",
+    "SeqCorrectCount": "The number of correctly predicted spans in a sequence.",
+    "RMSE": "Root mean square error (RMSE) measures the the difference between "
+    "values predicted by the model and the values observed.",
+    "Absolute Error": "Absolute error is the absolute discrepancy between the "
+    "prediction and true value.",
+}
+
+
+def get_metric_descriptions() -> dict[str, str]:
+    """getter for metric description dictionary"""
+    return _metric_to_descriptions

--- a/backend/templates/controller.mustache
+++ b/backend/templates/controller.mustache
@@ -1,6 +1,6 @@
 import connexion
 import six
-from typing import List
+from typing import List, Dict
 {{#imports}}{{import}}  # noqa: E501
 {{/imports}}
 from {{packageName}} import util

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -52,6 +52,28 @@ paths:
                 items:
                   $ref: "#/components/schemas/LanguageCode"
 
+  /metricdescriptions:
+    get:
+      summary: Return all metric descriptions
+      operationId: metricDescriptionsGet
+      security: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+
   /benchmarkconfigs:
     get:
       summary: Returns all benchmark configs matching the specification

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -52,7 +52,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/LanguageCode"
 
-  /metricdescriptions:
+  /metric-descriptions:
     get:
       summary: Return all metric descriptions
       operationId: metricDescriptionsGet


### PR DESCRIPTION
This PR adds the mapping of metric names --> descriptions to the backend. 
This aims to solve Issue #426 UI Optimization Plan where we can explain metrics to users.

## Comments
In `metric_descriptions.py`, the description strings had to be broken down in the form of `"xxx"\n"xxx"` to pass the format checker (error `falke8 E501 line too long`)

## Discussion

In the beginning, we considered to save a dataclass by referencing the documentation [supported_metrics.md](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_metrics.md)
```py
class MetricDescription:
    id: int
    name: str
    description: str
    used_tasks: list[TaskType]
    ref_url: str=""
```
But considering the use case for this class is only to look up the descriptions, and not the other attributes, we figured we actually only needed a dictionary.
All the other information (reference URL and used tasks) can be found in the documentation if users wanted to learn more.

## Next Steps
I will have two separate PRs for adding these descriptions in (1) system submit drawer and (2) analysis page.

Thanks to @lyuyangh for all the suggestions and discussions!
