### PR TITLE
Update flake8 url in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
         files: '\.py$'
-  - repo: https://gitlab.com/pycqa/flake8.git
+  - repo: https://github.com/PyCQA/flake8.git
     rev: 5.0.4
     hooks:
       - id: flake8
@@ -27,7 +27,7 @@ repos:
         files: '\.py$'
         args: ["--py39-plus"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.982'
+    rev: "v0.982"
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
Today's pre-commits were effected by this error message:

```
stderr:
    remote: The project you were looking for could not be found or you don't have permission to view it.
    fatal: repository '<https://gitlab.com/pycqa/flake8.git/>' not found

```

This is because `flake8` migrated from gitlab to github (see [[PyCQA's own PR](https://github.com/pycqa/flake8/pull/1305)](https://github.com/pycqa/flake8/pull/1305))
The new link is now: [https://github.com/PyCQA/flake8.git](https://github.com/PyCQA/flake8.git)

Pre-commits should be fine after this update.