### PR TITLE
Fix security definitions in GET system & GET benchmark

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -81,6 +81,10 @@ paths:
     get:
       summary: Returns benchmark metadata by id
       operationId: benchmarkGetById
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+        - {}
       description: Returns benchmark metadata by id.
       parameters:
         - in: path
@@ -260,6 +264,10 @@ paths:
     get:
       summary: Returns system metadata info by id
       operationId: systemsGetById
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+        - {}
       description: |
         Returns a system_metadata by id. id is the DB id so it is mostly used
         internally.


### PR DESCRIPTION
Added security definitions in GET `/systems/{system_id}` and `/benchmark/{benchmark_id}`to explicitly allow 1. API key users 2. Cognito logged-in users (bearer auth) 3. non-logged-in users to view systems and benchmarks. 

The main point here is adding the `- {}` definition, or else non-logged-in users will get rejected with 401 for public systems and benchmarks. I missed this use case. Permission check for private systems/benchmarks is still enforced in the backend.