### PR TITLE
Refactor system table filter and sorter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
         files: '\.py$'
-  - repo: https://gitlab.com/pycqa/flake8.git
+  - repo: https://github.com/PyCQA/flake8.git
     rev: 5.0.4
     hooks:
       - id: flake8
@@ -27,7 +27,7 @@ repos:
         files: '\.py$'
         args: ["--py39-plus"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.982'
+    rev: "v0.982"
     hooks:
       - id: mypy
         additional_dependencies:

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -135,11 +135,13 @@ class SystemDBUtils:
         if ids:
             search_conditions.append({"_id": {"$in": [ObjectId(_id) for _id in ids]}})
         if system_name:
-            search_conditions.append({"system_name": {"$regex": rf"^{system_name}.*"}})
+            search_conditions.append({"system_name": {"$regex": rf"{system_name}.*"}})
         if task:
             search_conditions.append({"task": task})
         if dataset_name:
-            search_conditions.append({"dataset.dataset_name": dataset_name})
+            search_conditions.append(
+                {"dataset.dataset_name": {"$regex": rf"{dataset_name}.*"}}
+            )
         if subdataset_name:
             search_conditions.append({"dataset.sub_dataset": subdataset_name})
         if source_language:

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -252,6 +252,7 @@ export function SystemTableContent({
     filters: Record<string, FilterValue | null>,
     sorter: SorterResult<SystemModel> | SorterResult<SystemModel>[]
   ) => {
+    // Handle filter change
     for (const k in filters) {
       if (
         k === "dataset.split" &&
@@ -262,6 +263,8 @@ export function SystemTableContent({
         onFilterChange({ task: filters[k]?.toString() });
       }
     }
+    // Handle sorter change
+    // Only one sorted column allowed now
     if (!(sorter instanceof Array)) {
       const sortFieldName =
         sorter.column === undefined
@@ -282,7 +285,7 @@ export function SystemTableContent({
         sortFieldName === undefined &&
         filterValue.sortField !== "created_at"
       ) {
-        // default filter
+        // Default sorted column
         onFilterChange({ sortField: "created_at", sortDir: "desc" });
       }
     }

--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -62,6 +62,7 @@ export function SystemTableContent({
     width: 135,
     ellipsis: true,
     align: "center",
+    sorter: true,
   }));
 
   function showSystemAnalysis(systemID: string) {
@@ -183,6 +184,7 @@ export function SystemTableContent({
       render: (_, record) => record.created_at.format("MM/DD/YYYY HH:mm"),
       width: 130,
       align: "center",
+      sorter: true,
     },
     {
       dataIndex: "system_tags",
@@ -246,7 +248,7 @@ export function SystemTableContent({
   };
 
   const handleTableChange = (
-    pagination: TablePaginationConfig,
+    _pagination: TablePaginationConfig,
     filters: Record<string, FilterValue | null>,
     sorter: SorterResult<SystemModel> | SorterResult<SystemModel>[]
   ) => {
@@ -258,6 +260,30 @@ export function SystemTableContent({
         onFilterChange({ split: filters[k]?.toString() });
       } else if (k === "task" && filters[k]?.toString() !== filterValue.task) {
         onFilterChange({ task: filters[k]?.toString() });
+      }
+    }
+    if (!(sorter instanceof Array)) {
+      const sortFieldName =
+        sorter.column === undefined
+          ? undefined
+          : sorter.column.title === "Created At"
+          ? "created_at"
+          : sorter.column.title?.toString();
+      if (
+        sortFieldName !== undefined &&
+        (sortFieldName !== filterValue.sortField ||
+          !sorter.order?.toString().startsWith(filterValue.sortDir))
+      ) {
+        onFilterChange({
+          sortField: sortFieldName,
+          sortDir: sorter.order?.toString() === "descend" ? "desc" : "asc",
+        });
+      } else if (
+        sortFieldName === undefined &&
+        filterValue.sortField !== "created_at"
+      ) {
+        // default filter
+        onFilterChange({ sortField: "created_at", sortDir: "desc" });
       }
     }
   };

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -10,13 +10,8 @@ import {
   Popconfirm,
   Radio,
 } from "antd";
-// import { TaskSelect } from "..";
 import { TaskCategory } from "../../clients/openapi";
-import {
-  ArrowDownOutlined,
-  ArrowUpOutlined,
-  WarningOutlined,
-} from "@ant-design/icons";
+import { WarningOutlined } from "@ant-design/icons";
 import { SystemModel } from "../../models";
 import { LoginState, useUser } from "../useUser";
 import { backendClient, parseBackendError } from "../../clients";
@@ -205,50 +200,6 @@ export function SystemTableTools({
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
         {mineVsAllSystemsToggle}
-        {/* <Select
-          options={["test", "validation", "train", "all"].map((opt) => ({
-            value: opt,
-            label: opt,
-          }))}
-          value={value.split || undefined}
-          placeholder="Dataset split"
-          onChange={(value) => onChange({ split: value })}
-          style={{ minWidth: "120px" }}
-        />
-        <TaskSelect
-          taskCategories={taskCategories}
-          allowClear
-          value={value.task || undefined}
-          onChange={(value) => onChange({ task: value || "" })}
-          placeholder="All Tasks"
-          style={{ minWidth: "150px" }}
-        /> */}
-        <div style={{ display: "flex", flexDirection: "row" }}>
-          <Select
-            options={[
-              ...metricOptions.map((opt) => ({ value: opt, label: opt })),
-              { value: "created_at", label: "Created At" },
-            ]}
-            value={value.sortField}
-            onChange={(value) => onChange({ sortField: value })}
-            style={{ minWidth: "120px" }}
-          />
-          <Tooltip title="Click to change sort direction">
-            <Button
-              icon={
-                value.sortDir === "asc" ? (
-                  <ArrowUpOutlined />
-                ) : (
-                  <ArrowDownOutlined />
-                )
-              }
-              onClick={() =>
-                onChange({ sortDir: value.sortDir === "asc" ? "desc" : "asc" })
-              }
-            />
-          </Tooltip>
-        </div>
-
         <Input.Search
           placeholder="Search by system name"
           value={value.name}

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -10,7 +10,7 @@ import {
   Popconfirm,
   Radio,
 } from "antd";
-import { TaskSelect } from "..";
+// import { TaskSelect } from "..";
 import { TaskCategory } from "../../clients/openapi";
 import {
   ArrowDownOutlined,
@@ -205,7 +205,7 @@ export function SystemTableTools({
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
         {mineVsAllSystemsToggle}
-        <Select
+        {/* <Select
           options={["test", "validation", "train", "all"].map((opt) => ({
             value: opt,
             label: opt,
@@ -222,7 +222,7 @@ export function SystemTableTools({
           onChange={(value) => onChange({ task: value || "" })}
           placeholder="All Tasks"
           style={{ minWidth: "150px" }}
-        />
+        /> */}
         <div style={{ display: "flex", flexDirection: "row" }}>
           <Select
             options={[

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -190,6 +190,24 @@ export function SystemTableTools({
     );
   }
 
+  const handleSearch = (query: string) => {
+    let systemQuery = undefined;
+    let datasetQuery = undefined;
+    const segments = query.split(";");
+    segments.forEach((seg) => {
+      const components = seg.split(":");
+      const property = components[0].trim();
+      if (property === "system" && components.length > 1) {
+        systemQuery =
+          components[1]?.trim().length > 0 ? components[1].trim() : undefined;
+      } else if (property === "dataset" && components.length > 0) {
+        datasetQuery =
+          components[1]?.trim().length > 0 ? components[1].trim() : undefined;
+      }
+    });
+    onChange({ name: systemQuery, dataset: datasetQuery });
+  };
+
   return (
     <div style={{ width: "100%" }}>
       <Space style={{ width: "fit-content", float: "left" }}>
@@ -200,11 +218,13 @@ export function SystemTableTools({
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
         {mineVsAllSystemsToggle}
-        <Input.Search
-          placeholder="Search by system name"
-          value={value.name}
-          onChange={(e) => onChange({ name: e.target.value })}
-        />
+        <Tooltip title="Search by system name and/or dataset name. Query format is 'system: target name; dataset: target name'.">
+          <Input.Search
+            placeholder="Search by system/dataset name"
+            onChange={(e) => handleSearch(e.target.value)}
+            style={{ minWidth: "300px" }}
+          />
+        </Tooltip>
 
         <Select
           mode="tags"

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -206,6 +206,9 @@ export function SystemsTable() {
         setSelectedSystemIDs={setSelectedSystemIDs}
         onActiveSystemChange={onActiveSystemChange}
         showEditDrawer={showEditDrawer}
+        onFilterChange={onFilterChange}
+        filterValue={filters}
+        taskCategories={taskCategories}
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>


### PR DESCRIPTION
This PR is related to issue #485 

## Previous filters and sorters

![Screen Shot 2022-11-16 at 4 29 11 PM](https://user-images.githubusercontent.com/71625258/202298335-4b70129b-9a1b-4484-91b7-00cd20b46747.png)

## Refactor: move filter lists and sorter to the system table header
* It passes the filter and sorter settings to the backend client and retrieve a new list of systems every time. 
* It supports one sorted column at a time as before. The default sorted column is `Created At` in descending order. 
* It can also update and parse the settings in the url.

![Screen Shot 2022-11-16 at 4 30 34 PM](https://user-images.githubusercontent.com/71625258/202298555-0b4c7601-73f6-446e-bdaf-e38cd3a5db8d.png)

![Screen Shot 2022-11-16 at 4 31 07 PM](https://user-images.githubusercontent.com/71625258/202298698-9fcca4dc-e5f9-4683-a95a-9974884629eb.png)

![Screen Shot 2022-11-16 at 4 32 07 PM](https://user-images.githubusercontent.com/71625258/202298851-de5a8c3f-2c79-42c9-8b00-5b8e0d459890.png)

