### PR TITLE
fix: Bump openapi version

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.16"
+  version: "0.2.17"
   contact:
     email: "explainaboard@gmail.com"
   license:


### PR DESCRIPTION
Embarrassingly, I just made the same mistake I mentioned to avoid this morning 🤦 
It's good that at least the CI failed since we cannot release the same version twice