### PR TITLE
fix: bump api version

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.17"
+  version: "0.2.18"
   contact:
     email: "explainaboard@gmail.com"
   license:


### PR DESCRIPTION
Same situation as #519 . 
#341 is indeed useful.

Both my PR and another PR that gets merged into the main branch update the api version by 1, but and I'm not seeing any merge conflicts. So I guess I should have checked the api version number on the main branch even if there is no merge conflict.


