### PR TITLE
highlight submit system button

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
-  Button,
-  ButtonProps,
+  // Button,
+  // ButtonProps,
   Input,
   Select,
   Space,
@@ -21,6 +21,7 @@ import { SystemModel } from "../../models";
 import { LoginState, useUser } from "../useUser";
 import { backendClient, parseBackendError } from "../../clients";
 import { FilterUpdate, SystemFilter } from "./SystemFilter";
+import Button, { ButtonProps } from "antd-button-color";
 
 interface Props {
   systems: SystemModel[];
@@ -276,7 +277,11 @@ function NewSystemButton(props: ButtonProps) {
   const { login, state } = useUser();
   if (state === LoginState.yes)
     return (
-      <Button danger type="primary" {...props}>
+      <Button
+        style={{ backgroundColor: "#28a745", borderColor: "#28a745" }}
+        type="primary"
+        {...props}
+      >
         Submit New System
       </Button>
     );
@@ -286,7 +291,10 @@ function NewSystemButton(props: ButtonProps) {
       placement="topLeft"
       defaultVisible
     >
-      <Button danger type="default" onClick={login}>
+      <Button
+        onClick={login}
+        style={{ borderColor: "#28a745", color: "#28a745" }}
+      >
         Submit New System
       </Button>
     </Tooltip>

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -273,16 +273,22 @@ export function SystemTableTools({
 }
 
 function NewSystemButton(props: ButtonProps) {
-  const { state } = useUser();
+  const { login, state } = useUser();
   if (state === LoginState.yes)
     return (
-      <Button type="primary" {...props}>
-        New
+      <Button danger type="primary" {...props}>
+        Submit New System
       </Button>
     );
   return (
-    <Tooltip title="Please log in to submit new systems" placement="topLeft">
-      <Button disabled>New</Button>
+    <Tooltip
+      title="Please log in to submit new systems"
+      placement="topLeft"
+      defaultVisible
+    >
+      <Button danger type="default" onClick={login}>
+        Submit New System
+      </Button>
     </Tooltip>
   );
 }

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
-  // Button,
-  // ButtonProps,
+  Button,
+  ButtonProps,
   Input,
   Select,
   Space,
@@ -21,7 +21,6 @@ import { SystemModel } from "../../models";
 import { LoginState, useUser } from "../useUser";
 import { backendClient, parseBackendError } from "../../clients";
 import { FilterUpdate, SystemFilter } from "./SystemFilter";
-import Button, { ButtonProps } from "antd-button-color";
 
 interface Props {
   systems: SystemModel[];


### PR DESCRIPTION
This PR is related to issue #516 

If the user hasn't logged in, they will see System page like this. The tooltip is default visible. User can click either 'Log in' button or 'Submit New System' button to log in.

 
<img width="1232" alt="Screen Shot 2022-11-17 at 2 30 15 PM" src="https://user-images.githubusercontent.com/71625258/202541661-2c5a7422-6c39-4ff2-ae66-bc9c3b13f82b.png">

If the user has logged in, they will see System page like this.

<img width="1238" alt="Screen Shot 2022-11-17 at 2 30 36 PM" src="https://user-images.githubusercontent.com/71625258/202541962-e0f5ed98-9247-4ce3-a242-7705eebda7ab.png">
