### PR TITLE
Upgrade sdk to v0.12.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 apache-beam~=2.41.0
 boto3~=1.24.68
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
-explainaboard == 0.11.2
+explainaboard == 0.12.0
 Flask-PyMongo~=2.3.0
 google-cloud-storage~=2.5.0
 iso-639~=0.4.5

--- a/backend/src/impl/analyses/significance_analysis.py
+++ b/backend/src/impl/analyses/significance_analysis.py
@@ -1,7 +1,6 @@
 import numpy as np
 from explainaboard.info import SysOutputInfo
 from explainaboard.metrics.metric import Metric, MetricStats
-
 from explainaboard_web.models import SignificanceTestInfo
 
 

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -8,8 +8,9 @@ from datetime import datetime
 from typing import Any, NamedTuple
 
 from bson import ObjectId
-from explainaboard import DatalabLoaderOption, FileType, Source
-from explainaboard.loaders.loader_registry import get_loader_class
+from explainaboard import DatalabLoaderOption, FileType, Source, get_loader_class
+from pymongo.client_session import ClientSession
+
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
@@ -24,7 +25,6 @@ from explainaboard_web.models import (
     SystemOutput,
     SystemOutputProps,
 )
-from pymongo.client_session import ClientSession
 
 
 class SystemDBUtils:

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -9,8 +9,6 @@ from typing import Any, NamedTuple
 
 from bson import ObjectId
 from explainaboard import DatalabLoaderOption, FileType, Source, get_loader_class
-from pymongo.client_session import ClientSession
-
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
@@ -25,6 +23,7 @@ from explainaboard_web.models import (
     SystemOutput,
     SystemOutputProps,
 )
+from pymongo.client_session import ClientSession
 
 
 class SystemDBUtils:

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -8,11 +8,15 @@ import os
 from functools import lru_cache
 
 import pandas as pd
-from explainaboard import DatalabLoaderOption, TaskType, get_processor_class
+from explainaboard import (
+    DatalabLoaderOption,
+    TaskType,
+    get_loader_class,
+    get_processor_class,
+)
 from explainaboard.analysis.analyses import BucketAnalysis
 from explainaboard.analysis.case import AnalysisCase
 from explainaboard.info import SysOutputInfo
-from explainaboard.loaders import get_loader_class
 from explainaboard.metrics.metric import SimpleMetricStats
 from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -21,10 +21,6 @@ from explainaboard.metrics.metric import SimpleMetricStats
 from explainaboard.serialization.serializers import PrimitiveSerializer
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.typing_utils import narrow
-from flask import current_app
-from pymongo import ASCENDING, DESCENDING
-from pymongo.client_session import ClientSession
-
 from explainaboard_web.impl.analyses.significance_analysis import (
     pairwise_significance_test,
 )
@@ -64,6 +60,9 @@ from explainaboard_web.models import (
     TaskCategory,
 )
 from explainaboard_web.models import User as modelUser
+from flask import current_app
+from pymongo import ASCENDING, DESCENDING
+from pymongo.client_session import ClientSession
 
 
 def _is_creator(obj: System | BenchmarkConfig, user: authUser) -> bool:

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -18,7 +18,6 @@ from explainaboard.analysis.analyses import BucketAnalysis
 from explainaboard.analysis.case import AnalysisCase
 from explainaboard.info import SysOutputInfo
 from explainaboard.metrics.metric import SimpleMetricStats
-from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.typing_utils import narrow
 from flask import current_app
@@ -56,7 +55,6 @@ from explainaboard_web.models.language_code import LanguageCode
 from explainaboard_web.models.system import System
 from explainaboard_web.models.system_analyses_return import SystemAnalysesReturn
 from explainaboard_web.models.system_create_props import SystemCreateProps
-from explainaboard_web.models.system_info import SystemInfo
 from explainaboard_web.models.system_update_props import SystemUpdateProps
 from explainaboard_web.models.systems_analyses_body import SystemsAnalysesBody
 from explainaboard_web.models.systems_return import SystemsReturn
@@ -426,16 +424,14 @@ def systems_analyses_post(body: SystemsAnalysesBody):
     # performance significance test if there are two systems
     sig_info = []
     if len(systems) == 2:
-        system1_info: SystemInfo = systems[0].get_system_info()
-        system1_info_dict = general_to_dict(system1_info)
+        system1_info_dict = systems[0].get_system_info().to_dict()
         system1_output_info = SysOutputInfo.from_dict(system1_info_dict)
 
         system1_metric_stats: list[SimpleMetricStats] = [
             SimpleMetricStats(stat) for stat in systems[0].get_metric_stats()[0]
         ]
 
-        system2_info: SystemInfo = systems[1].get_system_info()
-        system2_info_dict = general_to_dict(system2_info)
+        system2_info_dict = systems[1].get_system_info().to_dict()
         system2_output_info = SysOutputInfo.from_dict(system2_info_dict)
         system2_metric_stats: list[SimpleMetricStats] = [
             SimpleMetricStats(stat) for stat in systems[1].get_metric_stats()[0]
@@ -450,8 +446,7 @@ def systems_analyses_post(body: SystemsAnalysesBody):
 
     for system in systems:
         system_info = system.get_system_info()
-        system_info_dict = general_to_dict(system_info)
-        system_output_info = SysOutputInfo.from_dict(system_info_dict)
+        system_output_info = SysOutputInfo.from_dict(system_info.to_dict())
 
         for analysis in system_output_info.analyses:
             if (

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -143,12 +143,24 @@ class SystemModel(System):
             blob_name,
             json.dumps(system_output.samples),
         )
+        serializer = PrimitiveSerializer()
+        system_output_metadata = dataclasses.asdict(system_output.metadata)
+        system_output_metadata["custom_features"] = serializer.serialize(
+            system_output.metadata.custom_features
+        )
+        # TODO(lyuyang): This related to a bug in the SDK: custom_analyses aren't
+        # deserialized properly so it is actually a dict. When that is fixed
+        # in the SDK, this code also needs to be updated.
+        system_output_metadata[
+            "custom_analyses"
+        ] = system_output.metadata.custom_analyses
+
         DBUtils.update_one_by_id(
             DBUtils.DEV_SYSTEM_METADATA,
             self.system_id,
             {
                 "system_output": blob_name,
-                "system_output_metadata": dataclasses.asdict(system_output.metadata),
+                "system_output_metadata": system_output_metadata,
             },
             session=session,
         )

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -8,10 +8,12 @@ from datetime import datetime
 from importlib.metadata import version
 from typing import Any, Final
 
-from explainaboard import get_processor
+from explainaboard import TaskType, get_processor_class
 from explainaboard.loaders.file_loader import FileLoaderReturn
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.serialization.legacy import general_to_dict
+from pymongo.client_session import ClientSession
+
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
 from explainaboard_web.impl.storage import get_storage
 from explainaboard_web.impl.utils import (
@@ -21,7 +23,6 @@ from explainaboard_web.impl.utils import (
 )
 from explainaboard_web.models.system import System
 from explainaboard_web.models.system_info import SystemInfo
-from pymongo.client_session import ClientSession
 
 
 class SystemModel(System):
@@ -164,11 +165,8 @@ class SystemModel(System):
                 return
 
         def _process():
-            processor = get_processor(self.task)
-            metrics_lookup = {
-                metric.name: metric
-                for metric in get_processor(self.task).full_metric_list()
-            }
+            processor = get_processor_class(TaskType(self.task))()
+            metrics_lookup = processor.full_metric_list().copy()
             metric_configs: list[MetricConfig] = []
             for metric_name in self.metric_names:
                 if metric_name not in metrics_lookup:

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -14,8 +14,6 @@ from explainaboard.info import OverallStatistics, SysOutputInfo
 from explainaboard.loaders.file_loader import FileLoaderReturn
 from explainaboard.metrics.metric import MetricConfig, Score
 from explainaboard.serialization.serializers import PrimitiveSerializer
-from pymongo.client_session import ClientSession
-
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
 from explainaboard_web.impl.storage import get_storage
 from explainaboard_web.impl.utils import (
@@ -24,6 +22,7 @@ from explainaboard_web.impl.utils import (
     unbinarize_bson,
 )
 from explainaboard_web.models.system import System
+from pymongo.client_session import ClientSession
 
 
 class SystemModel(System):

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -143,14 +143,22 @@ class SystemModel(System):
             blob_name,
             json.dumps(system_output.samples),
         )
-        serializer = PrimitiveSerializer()
         system_output_metadata = dataclasses.asdict(system_output.metadata)
-        system_output_metadata["custom_features"] = serializer.serialize(
-            system_output.metadata.custom_features
-        )
-        # TODO(lyuyang): This related to a bug in the SDK: custom_analyses aren't
-        # deserialized properly so it is actually a dict. When that is fixed
-        # in the SDK, this code also needs to be updated.
+        # TODO(lyuyang): This related to a bug in the SDK: custom_features and
+        # custom_analyses aren't deserialized properly in some cases. When that
+        # is fixed in the SDK, this code also needs to be updated.
+        serializer = PrimitiveSerializer()
+        system_output_metadata[
+            "custom_features"
+        ] = system_output.metadata.custom_features
+        if system_output.metadata.custom_features:
+            levels = list(system_output_metadata["custom_features"].values())
+            if levels:
+                features = list(levels[0].values())
+                if features and not isinstance(features[0], dict):
+                    system_output_metadata["custom_features"] = serializer.serialize(
+                        system_output.metadata.custom_features
+                    )
         system_output_metadata[
             "custom_analyses"
         ] = system_output.metadata.custom_analyses

--- a/backend/src/tests/test_get_tasks.py
+++ b/backend/src/tests/test_get_tasks.py
@@ -1,7 +1,8 @@
 import unittest
 
-from explainaboard import get_processor
+from explainaboard import TaskType, get_processor_class
 from explainaboard.loaders.loader_registry import get_loader_class
+
 from explainaboard_web.impl.tasks import get_task_categories
 
 
@@ -19,7 +20,9 @@ class TestTasks(unittest.TestCase):
             self.assertIsNotNone(task_category.description)
             self.assertIsNotNone(task_category.name)
             for task in task_category.tasks:
-                supported_metrics = get_processor(task.name).full_metric_list()
+                supported_metrics = get_processor_class(
+                    TaskType(task.name)
+                ).full_metric_list()
                 supported_formats = get_loader_class(task.name).supported_file_types()
                 self.assertEqual(
                     len(supported_metrics),

--- a/backend/src/tests/test_get_tasks.py
+++ b/backend/src/tests/test_get_tasks.py
@@ -1,7 +1,6 @@
 import unittest
 
 from explainaboard import TaskType, get_loader_class, get_processor_class
-
 from explainaboard_web.impl.tasks import get_task_categories
 
 
@@ -25,7 +24,7 @@ class TestTasks(unittest.TestCase):
                 supported_formats = get_loader_class(task.name).supported_file_types()
                 self.assertEqual(
                     len(supported_metrics),
-                    len({x.name for x in supported_metrics}),
+                    len(supported_metrics),
                     f"duplicate metric names in {task.name}",
                 )
                 self.assertGreater(len(supported_formats.custom_dataset), 0)

--- a/backend/src/tests/test_get_tasks.py
+++ b/backend/src/tests/test_get_tasks.py
@@ -1,7 +1,6 @@
 import unittest
 
-from explainaboard import TaskType, get_processor_class
-from explainaboard.loaders.loader_registry import get_loader_class
+from explainaboard import TaskType, get_loader_class, get_processor_class
 
 from explainaboard_web.impl.tasks import get_task_categories
 

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -147,7 +147,7 @@ export function ComboAnalysisChart(props: Props) {
       splitArea: {
         show: true,
       },
-      name: analysis.comboFeatures[1],
+      name: analysis.comboFeatures[0],
       nameLocation: "middle",
       nameTextStyle: {
         padding: [1, 0, 0, 0],
@@ -161,7 +161,7 @@ export function ComboAnalysisChart(props: Props) {
       splitArea: {
         show: true,
       },
-      name: analysis.comboFeatures[0],
+      name: analysis.comboFeatures[1],
       nameTextStyle: {
         fontWeight: "bold",
         fontSize: 10,

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -4,7 +4,7 @@ import { SystemModel } from "../../../../models";
 import { BarChart } from "../../BarChart";
 import { BucketSlider } from "../../BucketSlider";
 import { BucketIntervals, ResultFineGrainedParsed } from "../../types";
-import { unwrapConfidence } from "../../utils";
+import { unwrapValue, unwrapConfidence } from "../../utils";
 
 interface Props {
   systems: SystemModel[];
@@ -82,7 +82,7 @@ export function FineGrainedBarChart(props: Props) {
   const resultsConfidenceScores: Array<[number, number]>[] = [];
   for (const result of results) {
     resultsNumbersOfSamples.push(result.numbersOfSamples);
-    resultsValues.push(result.performances.map((perf) => perf.value));
+    resultsValues.push(result.performances.map((perf) => unwrapValue(perf)));
     resultsConfidenceScores.push(
       result.performances.map((perf) => unwrapConfidence(perf))
     );

--- a/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BarChart } from "../..";
 import { SystemAnalysesReturn } from "../../../clients/openapi";
 import { SystemModel } from "../../../models";
-import { getOverallMap, unwrapConfidence } from "../utils";
+import { unwrapValue, unwrapConfidence, getOverallMap } from "../utils";
 import { AnalysisPanel } from "./AnalysisPanel";
 
 interface Props {
@@ -44,7 +44,7 @@ export function OverallMetricsBarChart({
     for (const metricName of metricNames) {
       if (metricName in overallMap) {
         const metricResults = overallMap[metricName];
-        metricPerformance.push(metricResults.value);
+        metricPerformance.push(unwrapValue(metricResults));
         metricConfidence.push(unwrapConfidence(metricResults));
       } else {
         metricPerformance.push(0);

--- a/frontend/src/components/Analysis/types.tsx
+++ b/frontend/src/components/Analysis/types.tsx
@@ -1,6 +1,6 @@
 // interface modified from https://app.quicktype.io/
 
-import { Performance, ComboCount } from "../../clients/openapi";
+import { ComboCount, MetricResult } from "../../clients/openapi";
 
 export interface ResultFineGrainedParsed {
   /**
@@ -21,7 +21,7 @@ export interface ResultFineGrainedParsed {
   // The number of samples in each bucket
   numbersOfSamples: number[];
   // performances[i]: performance (value/confidence) for bucket i
-  performances: Performance[];
+  performances: MetricResult[];
   // Used by combo count analyses
   comboCounts: ComboCount[];
   // Combo count analyses features. Used by combo count analyses

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.17"
+  version: "0.2.18"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -719,26 +719,8 @@ components:
           additionalProperties:
             $ref: "#/components/schemas/FeatureType"
         metric_configs:
-          type: array
-          items:
-            $ref: "#/components/schemas/MetricConfig"
+          type: object
       required: [name, features, metric_configs]
-
-    MetricConfig:
-      type: object
-      properties:
-        name:
-          type: string
-        source_language:
-          type: string
-          nullable: true
-        target_language:
-          type: string
-          nullable: true
-        cls_name:
-          type: string
-      additionalProperties: true
-      required: [name, cls_name]
 
     FeatureType:
       type: object
@@ -777,8 +759,6 @@ components:
         target_language:
           type: string
           example: en
-        reload_stat:
-          type: boolean
         confidence_alpha:
           type: number
         analysis_levels:
@@ -797,12 +777,24 @@ components:
           type: object
           properties:
             overall:
-              type: array
+              type: object
               description: metrics for each analysis level
-              items:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Performance"
+              additionalProperties:
+                description: analysis level
+                type: object
+                additionalProperties:
+                  description: metric name
+                  $ref: "#/components/schemas/MetricResult"
+              example: {
+                "example": {
+                  "rouge2": {
+                    "values": {
+                      "score": {"value": 0.12},
+                      "score_ci": {"low": -0.07, "high": 0.34, "alpha": 0.05}
+                    }
+                  }
+                }
+              }
           required: [overall]
         dataset_name:
           type: string
@@ -822,7 +814,6 @@ components:
           system_name,
           source_language,
           target_language,
-          reload_stat,
           confidence_alpha,
           source_tokenizer,
           target_tokenizer,
@@ -840,6 +831,39 @@ components:
         variety:
           type: string
           example: "intl"
+
+    MetricResult:
+      type: object
+      properties:
+        values:
+          type: object
+          properties:
+            score:
+              $ref: "#/components/schemas/Score"
+            score_ci:
+              $ref: "#/components/schemas/ConfidenceInterval"
+      required: [values]
+
+    # --- MetricValue ---
+    Score:
+      type: object
+      properties:
+        value:
+          type: number
+      required: [value]
+
+    ConfidenceInterval:
+      type: object
+      properties:
+        low:
+          type: number
+        high:
+          type: number
+        alpha:
+          type: number
+      required: [low, high, alpha]
+
+    # --- MetricValue (END) ---
 
     APIError:
       type: object
@@ -1253,30 +1277,14 @@ components:
       properties:
         name:
           type: string
+        level:
+          type: string
         cls_name:
           type: string
+        details:
+          type: object
       additionalProperties: true
-
-    BucketPerformance:
-      type: object
-      properties:
-        n_samples:
-          type: number
-        bucket_samples:
-          type: array
-          items:
-            type: number
-        performances:
-          type: array
-          items:
-            $ref: "#/components/schemas/Performance"
-        bucket_name:
-          type: string
-        bucket_interval:
-          type: array
-          items:
-            type: number
-      required: [n_samples, bucket_samples, performances]
+      required: [name, level, cls_name, details]
 
     SingleAnalysis:
       type: object
@@ -1302,21 +1310,6 @@ components:
           items:
             $ref: "#/components/schemas/SignificanceTestInfo"
       required: [system_analyses]
-
-    Performance:
-      type: object
-      properties:
-        metric_name:
-          type: string
-        value:
-          type: number
-        confidence_score_low:
-          type: number
-          nullable: true
-        confidence_score_high:
-          type: number
-          nullable: true
-      required: [metric_name, value]
 
     ComboCount:
       type: object


### PR DESCRIPTION
I modified the following:
1. `get_loader()` -> `get_loader_class()`
2. `get_processor()` -> `get_processor_class()`
3. replaced `general_to_dict()` with serializer.serialize()`
4. modified `MetricResult` schema to match the one used by the SDK

I wanted to make as few changes as possible and stick to the current design in this PR. The part that gave me the most trouble is `Analysis/utils.tsx` which probably contains the most complex code in this repository (it probably needs to be). We can maybe think of ways to refactor it so it is more versatile and add better type annotations so it is easier to do upgrades like this. I can submit a PR to do that sometime in the future.

### Testing:
Passed all the items on the checklist. 
All unit tests are passing.

The confidence intervals for sst2 sample system output are a lot wider. Is this expected?
<img width="805" alt="image" src="https://user-images.githubusercontent.com/22896307/202878922-c59efce2-8d6b-4f24-8e34-8656d3ff4cf2.png">

- @PaulCCCCCCH Could you please take a look at "combo analysis" to make sure everything still works as expected? The chart is now clickable. It seems to be working but I am not sure.
- @OscarWang114 or @PaulCCCCCCH Could you please take a look at the changes I made in `Analysis/utils.tsx` and everything related to analysis? I made quite a few changes.

### Compatibility
1. `explainaboard_client` should be fine. I only changed the interface for `POST /systems/analyses` which is not used by the client.
2. No DB migration is required.