### PR TITLE
force isort to recognize explainaboard_web as a local folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: isort
         files: '\.py$'
-        args: ["--profile", "black"]
+        args: ["--profile", "black", "--known-local-folder", "explainaboard_web"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.0.0
     hooks:

--- a/backend/src/impl/analyses/significance_analysis.py
+++ b/backend/src/impl/analyses/significance_analysis.py
@@ -2,6 +2,7 @@ import numpy as np
 from explainaboard.info import SysOutputInfo
 from explainaboard.metrics.metric import MetricStats
 from explainaboard.utils.typing_utils import unwrap
+
 from explainaboard_web.models import SignificanceTestInfo
 
 

--- a/backend/src/impl/auth.py
+++ b/backend/src/impl/auth.py
@@ -4,9 +4,10 @@ import secrets
 
 import boto3
 import jwt
+from flask import current_app, g
+
 from explainaboard_web.impl.db_utils.user_db_utils import UserDBUtils, UserInDB
 from explainaboard_web.impl.utils import abort_with_error_message
-from flask import current_app, g
 
 
 # Disables N802 to follow the naming scheme in the OpenAPI definition.

--- a/backend/src/impl/db_utils/benchmark_db_utils.py
+++ b/backend/src/impl/db_utils/benchmark_db_utils.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 import pandas as pd
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file
 from explainaboard.utils.typing_utils import unwrap
+from pandas import Series
+
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.constants import ALL_LANG, LING_WEIGHT, POP_WEIGHT
 from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
@@ -23,7 +25,6 @@ from explainaboard_web.models import (
     BenchmarkViewConfig,
     DatasetMetadata,
 )
-from pandas import Series
 
 
 @dataclass

--- a/backend/src/impl/db_utils/dataset_db_utils.py
+++ b/backend/src/impl/db_utils/dataset_db_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import marisa_trie
 from explainaboard.utils.cache_api import cache_online_file
 from explainaboard.utils.typing_utils import unwrap
+
 from explainaboard_web.models import DatasetMetadata, DatasetsReturn
 
 

--- a/backend/src/impl/db_utils/db_utils.py
+++ b/backend/src/impl/db_utils/db_utils.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 from typing import TypeVar
 
 from bson.objectid import InvalidId, ObjectId
-from explainaboard_web.impl.db import get_db
 from pymongo.client_session import ClientSession
 from pymongo.cursor import Cursor
 from pymongo.results import DeleteResult, InsertManyResult, UpdateResult
+
+from explainaboard_web.impl.db import get_db
 
 
 @dataclass

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -10,6 +10,8 @@ from typing import Any, NamedTuple
 from bson import ObjectId
 from explainaboard import DatalabLoaderOption, FileType, Source
 from explainaboard.loaders.loader_registry import get_loader_class
+from pymongo.client_session import ClientSession
+
 from explainaboard_web.impl.auth import get_user
 from explainaboard_web.impl.db_utils.dataset_db_utils import DatasetDBUtils
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
@@ -24,7 +26,6 @@ from explainaboard_web.models import (
     SystemOutput,
     SystemOutputProps,
 )
-from pymongo.client_session import ClientSession
 
 
 class SystemDBUtils:

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -17,6 +17,10 @@ from explainaboard.metrics.metric import SimpleMetricStats
 from explainaboard.serialization.legacy import general_to_dict
 from explainaboard.utils.cache_api import get_cache_dir, open_cached_file, sanitize_path
 from explainaboard.utils.typing_utils import narrow
+from flask import current_app
+from pymongo import ASCENDING, DESCENDING
+from pymongo.client_session import ClientSession
+
 from explainaboard_web.impl.analyses.significance_analysis import (
     pairwise_significance_test,
 )
@@ -56,9 +60,6 @@ from explainaboard_web.models import (
     TaskCategory,
 )
 from explainaboard_web.models import User as modelUser
-from flask import current_app
-from pymongo import ASCENDING, DESCENDING
-from pymongo.client_session import ClientSession
 
 
 def _is_creator(obj: System | BenchmarkConfig, user: authUser) -> bool:

--- a/backend/src/impl/init.py
+++ b/backend/src/impl/init.py
@@ -1,12 +1,13 @@
 import os
 
+from flask import Flask, request
+
 from explainaboard_web.impl.config import (
     LocalDevelopmentConfig,
     ProductionConfig,
     StagingConfig,
 )
 from explainaboard_web.impl.utils import abort_with_error_message, get_api_version
-from flask import Flask, request
 
 
 def init(app: Flask) -> Flask:

--- a/backend/src/impl/internal_models/system_model.py
+++ b/backend/src/impl/internal_models/system_model.py
@@ -12,6 +12,8 @@ from explainaboard import get_processor
 from explainaboard.loaders.file_loader import FileLoaderReturn
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.serialization.legacy import general_to_dict
+from pymongo.client_session import ClientSession
+
 from explainaboard_web.impl.db_utils.db_utils import DBUtils
 from explainaboard_web.impl.storage import get_storage
 from explainaboard_web.impl.utils import (
@@ -21,7 +23,6 @@ from explainaboard_web.impl.utils import (
 )
 from explainaboard_web.models.system import System
 from explainaboard_web.models.system_info import SystemInfo
-from pymongo.client_session import ClientSession
 
 
 class SystemModel(System):

--- a/backend/src/scripts/update_schema.py
+++ b/backend/src/scripts/update_schema.py
@@ -1,8 +1,9 @@
 import argparse
 import copy
 
-from explainaboard_web.impl.db_utils.db_utils import DBUtils
 from flask import Flask
+
+from explainaboard_web.impl.db_utils.db_utils import DBUtils
 
 """
 This is a utility script that can be used to update the schema of the database when

--- a/backend/src/tests/test_benchmark.py
+++ b/backend/src/tests/test_benchmark.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+
 from explainaboard_web.impl.constants import POP_WEIGHT
 from explainaboard_web.impl.db_utils.benchmark_db_utils import BenchmarkDBUtils
 

--- a/backend/src/tests/test_get_tasks.py
+++ b/backend/src/tests/test_get_tasks.py
@@ -2,6 +2,7 @@ import unittest
 
 from explainaboard import get_processor
 from explainaboard.loaders.loader_registry import get_loader_class
+
 from explainaboard_web.impl.tasks import get_task_categories
 
 


### PR DESCRIPTION
Because we generate the `explainaboard_web` directory, isort does not recognize `explainaboard_web` as a local folder. This PR forces isort to treat any import from `explainaboard_web` as a local import. Currently, local invocation of isort may give different results from the CI depending on how we set up our environments. This PR addresses that issue.

cc @noelchen90 