### PR TITLE
move dataset_split and task filter to system table header

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -251,29 +251,22 @@ export function SystemTableContent({
     filters: Record<string, FilterValue | null>,
     _sorter: SorterResult<SystemModel> | SorterResult<SystemModel>[]
   ) => {
-    console.log(filters);
-    for (const k in filters) {
-      if (
-        k === "dataset.split" &&
-        ((filters[k] === null && filterValue.split !== undefined) || // Reset filter
-          (filters[k] !== null &&
-            (filters[k] as unknown as string) !== filterValue.split))
-      ) {
-        onFilterChange({
-          split:
-            filters[k] === null ? undefined : (filters[k] as unknown as string),
-        });
-      } else if (
-        k === "task" &&
-        ((filters[k] === null && filterValue.split !== undefined) || // Reset filter
-          (filters[k] !== null &&
-            (filters[k] as unknown as string) !== filterValue.split))
-      ) {
-        onFilterChange({
-          task:
-            filters[k] === null ? undefined : (filters[k] as unknown as string),
-        });
-      }
+    let filterChanged = false;
+    const filterUpdate: Partial<SystemFilter> = {};
+    const dataset_split = filters["dataset.split"]
+      ? (filters["dataset.split"][0] as string)
+      : undefined;
+    if (dataset_split !== filterValue.split) {
+      filterChanged = true;
+      filterUpdate.split = dataset_split;
+    }
+    const task = filters["task"] ? (filters["task"][0] as string) : undefined;
+    if (task !== filterValue.task) {
+      filterChanged = true;
+      filterUpdate.task = task;
+    }
+    if (filterChanged) {
+      onFilterChange(filterUpdate);
     }
   };
 

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -10,7 +10,6 @@ import {
   Popconfirm,
   Radio,
 } from "antd";
-import { TaskSelect } from "..";
 import { TaskCategory } from "../../clients/openapi";
 import {
   ArrowDownOutlined,
@@ -208,24 +207,6 @@ export function SystemTableTools({
       </Space>
       <Space style={{ width: "fit-content", float: "right" }}>
         {mineVsAllSystemsToggle}
-        <Select
-          options={["test", "validation", "train", "all"].map((opt) => ({
-            value: opt,
-            label: opt,
-          }))}
-          value={value.split || undefined}
-          placeholder="Dataset split"
-          onChange={(value) => onChange({ split: value })}
-          style={{ minWidth: "120px" }}
-        />
-        <TaskSelect
-          taskCategories={taskCategories}
-          allowClear
-          value={value.task || undefined}
-          onChange={(value) => onChange({ task: value || "" })}
-          placeholder="All Tasks"
-          style={{ minWidth: "150px" }}
-        />
         <div style={{ display: "flex", flexDirection: "row" }}>
           <Select
             options={[

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -206,6 +206,9 @@ export function SystemsTable() {
         setSelectedSystemIDs={setSelectedSystemIDs}
         onActiveSystemChange={onActiveSystemChange}
         showEditDrawer={showEditDrawer}
+        onFilterChange={onFilterChange}
+        filterValue={filters}
+        taskCategories={taskCategories}
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>


### PR DESCRIPTION
This is a sub-component of PR #518 

## Move dataset split and task filter to the system table header
* It supports updating and reading from the url. If the column is filtered, the filter icon next to the column name is highlighted in blue.

<img width="1439" alt="Screen Shot 2022-11-21 at 5 06 07 PM" src="https://user-images.githubusercontent.com/71625258/203168581-f8def275-064e-4cc0-bd65-835149ae39b5.png">
