### PR TITLE
search systems by dataset name

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -106,7 +106,6 @@ export function SystemTableContent({
   }, [datasetSearchText, filterValue.task]);
 
   const onDatasetSearch = (value: string) => {
-    console.log("search:", value);
     setDatasetSearchText(value);
   };
 

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -206,6 +206,8 @@ export function SystemsTable() {
         setSelectedSystemIDs={setSelectedSystemIDs}
         onActiveSystemChange={onActiveSystemChange}
         showEditDrawer={showEditDrawer}
+        onFilterChange={onFilterChange}
+        filterValue={filters}
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>


### PR DESCRIPTION
This is a sub-component of PR #518 

## Search systems by dataset name
* The dataset filter is added to the table header. This is a custom filter, a searchable select list. Without search text, it will display some dataset names. With search text, the dataset list will be updated. 
* It supports updating and reading from the url.

![Screen Shot 2022-11-22 at 1 07 12 AM](https://user-images.githubusercontent.com/71625258/203238956-98a20c19-fbc7-4d6c-94cc-e4e600bb668b.png)

![Screen Shot 2022-11-22 at 1 07 46 AM](https://user-images.githubusercontent.com/71625258/203238984-a4cb8499-081f-4910-ae53-0ea9b26bf85c.png)

![Screen Shot 2022-11-22 at 1 08 04 AM](https://user-images.githubusercontent.com/71625258/203238995-64fbd67d-f28e-46f6-85c4-9eec6ba4a4cb.png)
