### PR TITLE
fix sorted column of system table

### DIFF
--- a/frontend/src/components/SystemsTable/SystemTableContent.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableContent.tsx
@@ -175,6 +175,13 @@ export function SystemTableContent({
       render: (_, record) => record.created_at.format("MM/DD/YYYY HH:mm"),
       width: 130,
       align: "center",
+      fixed: filterValue.sortField === "created_at" ? "right" : false,
+      sorter: filterValue.sortField === "created_at",
+      showSorterTooltip: false,
+      sortOrder:
+        filterValue.sortField === "created_at" && filterValue.sortDir === "asc"
+          ? "ascend"
+          : "descend",
     },
     {
       dataIndex: "system_tags",
@@ -186,9 +193,15 @@ export function SystemTableContent({
     },
   ];
   columns.sort(function (a, b) {
-    if (a.fixed === "left" && b.fixed !== "left") {
+    if (
+      (a.fixed === "left" && b.fixed !== "left") ||
+      (a.fixed !== "right" && b.fixed === "right")
+    ) {
       return -1;
-    } else if (b.fixed === "left" && a.fixed !== "left") {
+    } else if (
+      (b.fixed === "left" && a.fixed !== "left") ||
+      (b.fixed !== "right" && a.fixed === "right")
+    ) {
       return 1;
     }
     return 0;

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -228,9 +228,10 @@ export function SystemTableTools({
         />
         <div style={{ display: "flex", flexDirection: "row" }}>
           <Select
+            allowClear
             options={[
               ...metricOptions.map((opt) => ({ value: opt, label: opt })),
-              { value: "created_at", label: "Created At" },
+              { value: "created_at", label: "Sorted by" },
             ]}
             value={value.sortField}
             onChange={(value) => onChange({ sortField: value })}

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -227,11 +227,16 @@ export function SystemTableTools({
           style={{ minWidth: "150px" }}
         />
         <div style={{ display: "flex", flexDirection: "row" }}>
+          <Input
+            disabled
+            value="Sorted by"
+            style={{ width: "90px", color: "black" }}
+          />
           <Select
             allowClear
             options={[
               ...metricOptions.map((opt) => ({ value: opt, label: opt })),
-              { value: "created_at", label: "Sorted by" },
+              { value: "created_at", label: "Time" },
             ]}
             value={value.sortField}
             onChange={(value) => onChange({ sortField: value })}

--- a/frontend/src/components/SystemsTable/index.tsx
+++ b/frontend/src/components/SystemsTable/index.tsx
@@ -206,6 +206,7 @@ export function SystemsTable() {
         setSelectedSystemIDs={setSelectedSystemIDs}
         onActiveSystemChange={onActiveSystemChange}
         showEditDrawer={showEditDrawer}
+        filterValue={filters}
       />
       <AnalysisDrawer
         systems={systems.filter((sys) =>


### PR DESCRIPTION
This is a sub-component of PR #518 

## Fix the sorted column of System table
* The sorter selector is kept separately above the table, and the sorted column in the table is fixed to the left and the column header sorter is set to be the same as the sorting direction. 
* In the sorter selector, 'Created At' is changed to 'Sorted by' for easier understanding. 

![Screen Shot 2022-11-22 at 3 15 27 PM](https://user-images.githubusercontent.com/71625258/203415345-dce7d805-c8a9-48b8-b992-1e393b07d7ed.png)
