### PR TITLE
Now display one combo chart for each system

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -9,7 +9,11 @@ import {
   SystemsAnalysesBody,
 } from "../../../clients/openapi";
 import { WarningOutlined } from "@ant-design/icons";
-import { parseFineGrainedResults, valuesToIntervals } from "../utils";
+import {
+  hasDuplicate,
+  parseFineGrainedResults,
+  valuesToIntervals,
+} from "../utils";
 import { ResultFineGrainedParsed, BucketIntervals } from "../types";
 import ReactGA from "react-ga4";
 import { AnalysisButton } from "./AnalysisButton";
@@ -204,9 +208,7 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
 
   function getDrawerTitle(): React.ReactNode {
     const systemNames = systems.map((sys) => sys.system_name);
-    const distinctSystemNames = new Set(systemNames);
-    const duplicateNameWarning =
-      distinctSystemNames.size !== systemNames.length;
+    const duplicateNameWarning = hasDuplicate(systemNames);
     const duplicateNameWarningMsg =
       "The systems have duplicate names. Unique system IDs are attached to distinguish between them. Please change system names using the edit button on `Systems` page.";
     if (systems.length === 1) {

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -8,8 +8,8 @@ import { Col } from "antd";
 
 interface Props {
   title: string;
-  systems: SystemModel[];
-  analyses: ResultFineGrainedParsed[];
+  system: SystemModel;
+  analysis: ResultFineGrainedParsed;
   colSpan: 8 | 12 | 24;
   onEntryClick: (
     samples: number[][],
@@ -21,7 +21,7 @@ interface Props {
 }
 
 export function ComboAnalysisChart(props: Props) {
-  const { systems, analyses, title, onEntryClick, colSpan, addChartFile } =
+  const { system, analysis, title, onEntryClick, colSpan, addChartFile } =
     props;
   const [eChartsRef, setEChartsRef] = useState<ReactEChartsCore | null>();
   useEffect(() => {
@@ -32,17 +32,7 @@ export function ComboAnalysisChart(props: Props) {
     }
   });
 
-  // For now we only support combo analysis for single-system analysis.
-  if (analyses.length !== 1) {
-    return <></>;
-  }
-
-  const system = systems[0];
-  const analysis = analyses[0];
   const counts = analysis.comboCounts;
-  if (counts.length < 1) {
-    return <></>;
-  }
 
   // Gather all categories and assign index to each of them
   const cateMap = new Map<string, number>();

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -4,7 +4,7 @@ import { SystemModel } from "../../../../models";
 import { BarChart } from "../../BarChart";
 import { BucketSlider } from "../../BucketSlider";
 import { BucketIntervals, ResultFineGrainedParsed } from "../../types";
-import { unwrapValue, unwrapConfidence } from "../../utils";
+import { unwrapValue, unwrapConfidence, hasDuplicate } from "../../utils";
 
 interface Props {
   systems: SystemModel[];
@@ -34,8 +34,7 @@ export function FineGrainedBarChart(props: Props) {
   // For invariant variables across all systems, we can simply take from the first result
   function getSystemNames(systems: SystemModel[]) {
     const systemNames = systems.map((sys) => sys.system_name);
-    const distinctSystemNames = new Set(systemNames);
-    if (distinctSystemNames.size !== systemNames.length) {
+    if (hasDuplicate(systemNames)) {
       return systems.map((sys) => sys.system_name + "_" + sys.system_id);
     } else {
       return systemNames;

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -6,7 +6,7 @@ import { ExampleTable } from "../ExampleTable";
 import { FineGrainedBarChart } from "./FineGrainedBarChart";
 import { AnalysisCase } from "../../../../clients/openapi";
 import { backendClient, parseBackendError } from "../../../../clients";
-import { compareBucketOfCases } from "../../utils";
+import { compareBucketOfCases, hasDuplicate } from "../../utils";
 import { PageState } from "../../../../utils";
 import { ComboAnalysisChart } from "./ComboAnalysisChart";
 
@@ -59,9 +59,12 @@ export function MetricPane(props: Props) {
 
   function generateComboAnalysisChartTitle(
     analysis: ResultFineGrainedParsed,
-    system: SystemModel
+    system: SystemModel,
+    includeId: boolean
   ): string {
-    return `${analysis.featureDescription} for ${system.system_name}`;
+    return `${analysis.featureDescription} for ${system.system_name}${
+      includeId ? "_" + system.system_id : ""
+    }`;
   }
 
   function getColSpan(): 8 | 12 | 24 {
@@ -170,6 +173,8 @@ export function MetricPane(props: Props) {
   // Map the resultsFineGrainedParsed of the every element in systemAnalysesParsed
   // into columns. One column contains a single BarChart.
   const charts: JSX.Element[] = [];
+  const hasSameName = hasDuplicate(systems.map((sys) => sys.system_name));
+
   Object.keys(systemAnalysesParsed).forEach((feature) => {
     // Handles combo charts and bar charts differently
     if (feature.toLowerCase().startsWith("combo")) {
@@ -185,7 +190,11 @@ export function MetricPane(props: Props) {
 
         charts.push(
           <ComboAnalysisChart
-            title={generateComboAnalysisChartTitle(analysis, system)}
+            title={generateComboAnalysisChartTitle(
+              analysis,
+              system,
+              hasSameName
+            )}
             colSpan={chartColSpan}
             system={system}
             analysis={analysis}

--- a/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/OverallMetricsBarChart.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { BarChart } from "../..";
 import { SystemAnalysesReturn } from "../../../clients/openapi";
 import { SystemModel } from "../../../models";
-import { unwrapValue, unwrapConfidence, getOverallMap } from "../utils";
+import {
+  unwrapValue,
+  unwrapConfidence,
+  getOverallMap,
+  hasDuplicate,
+} from "../utils";
 import { AnalysisPanel } from "./AnalysisPanel";
 
 interface Props {
@@ -24,8 +29,7 @@ export function OverallMetricsBarChart({
 }: Props) {
   function getSystemNames(systems: SystemModel[]) {
     const systemNames = systems.map((sys) => sys.system_name);
-    const distinctSystemNames = new Set(systemNames);
-    if (distinctSystemNames.size !== systemNames.length) {
+    if (hasDuplicate(systemNames)) {
       return systems.map((sys) => sys.system_name + "_" + sys.system_id);
     } else {
       return systemNames;

--- a/frontend/src/components/Analysis/utils.tsx
+++ b/frontend/src/components/Analysis/utils.tsx
@@ -315,3 +315,8 @@ export function unwrapConfidence(perf: MetricResult): [number, number] {
   }
   return [-1, -1];
 }
+
+export function hasDuplicate(strings: string[]): boolean {
+  const distinctSet = new Set(strings);
+  return distinctSet.size !== strings.length;
+}


### PR DESCRIPTION
This PR implements #531 suggested by @neubig earlier today .

It also fixes #532 . The cause: I was returning `<></>` if there were multiple systems for combo analysis charts, making the `ref` object defined ealier point to nothing.