### PR TITLE
Add CI check for openapi version

### DIFF
--- a/.github/workflows/openapi-version-check.yml
+++ b/.github/workflows/openapi-version-check.yml
@@ -2,7 +2,7 @@ name: Openapi Version Check
 run-name: Verify version is bumped when openapi.yaml is updated
 
 on: # yamllint disable-line rule:truthy
-  push:
+  pull_request:
     branches: ["main"]
     paths: ["openapi/openapi.yaml"]
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Openapi version check
         run: |
-          function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+          function ver { printf "%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
           do_version_check() {
             prev="$1"
             new="$2"

--- a/.github/workflows/openapi-version-check.yml
+++ b/.github/workflows/openapi-version-check.yml
@@ -21,13 +21,15 @@ jobs:
         run: |
           version=$(sed -n "s/^  version: \"\(.*\)\"$/\1/p" openapi/openapi.yaml)
           echo "::set-output name=version::$version"
+          echo "new version: $version"
 
       - name: Get previous version
         id: prev_version
         run: |
-          git checkout ${{github.event.pull_request.base.ref}}
+          git checkout main
           version=$(sed -n "s/^  version: \"\(.*\)\"$/\1/p" openapi/openapi.yaml)
           echo "::set-output name=version::$version"
+          echo "previous version: $version"
 
       - name: Openapi version check
         run: |

--- a/.github/workflows/openapi-version-check.yml
+++ b/.github/workflows/openapi-version-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get previous version
         id: prev_version
         run: |
-          git checkout ${{github.event.before}}
+          git checkout ${{github.event.pull_request.base.ref}}
           version=$(sed -n "s/^  version: \"\(.*\)\"$/\1/p" openapi/openapi.yaml)
           echo "::set-output name=version::$version"
 

--- a/.github/workflows/openapi-version-check.yml
+++ b/.github/workflows/openapi-version-check.yml
@@ -1,0 +1,53 @@
+name: Openapi Version Check
+run-name: Verify version is bumped when openapi.yaml is updated
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: ["main"]
+    paths: ["openapi/openapi.yaml"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # checkout full tree
+          fetch-depth: 0
+
+      - name: Get new version
+        id: new_version
+        run: |
+          version=$(sed -n "s/^  version: \"\(.*\)\"$/\1/p" openapi/openapi.yaml)
+          echo "::set-output name=version::$version"
+
+      - name: Get previous version
+        id: prev_version
+        run: |
+          git checkout ${{github.event.before}}
+          version=$(sed -n "s/^  version: \"\(.*\)\"$/\1/p" openapi/openapi.yaml)
+          echo "::set-output name=version::$version"
+
+      - name: Openapi version check
+        run: |
+          function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+          do_version_check() {
+            prev="$1"
+            new="$2"
+            if [ $(ver $prev) -lt $(ver $new) ]; then
+              return 0
+            elif [ $(ver $prev) -gt $(ver $new) ]; then
+              echo "ERROR: The new openapi version needs to be greater than \
+              the previous verison."
+            else
+              echo "ERROR: Same openapi version. Remember to bump up openapi \
+              version after modifying openapi/openapi.yaml"
+            fi
+
+            echo "previous version:" $prev
+            echo "new version (the version just pushed):" $new
+            return 1
+          }
+          do_version_check ${{steps.prev_version.outputs.version }} \
+          ${{steps.new_version.outputs.version }}


### PR DESCRIPTION
closes #341 

This PR adds a workflow only triggered when there is a pull request to the `main` branch and specifically on the file `openapi/openapi.yaml`

Whenever there is a change in `openapi.yaml` file, it will compare the newer version to the previous version. And return unsuccessful if it is not bumped up.