### PR TITLE
pre-generate id for system creation

### DIFF
--- a/backend/src/impl/db_utils/db_utils.py
+++ b/backend/src/impl/db_utils/db_utils.py
@@ -31,7 +31,7 @@ class DBUtils:
     )
 
     @staticmethod
-    def _convert_id(_id: str):
+    def _convert_id(_id: str | ObjectId):
         try:
             return ObjectId(_id)
         # mongo accepts custom id
@@ -93,7 +93,7 @@ class DBUtils:
     @staticmethod
     def find_one_by_id(
         collection: DBCollection,
-        docid: str,
+        docid: str | ObjectId,
         projection: dict | None = None,
         session: ClientSession | None = None,
     ):
@@ -111,7 +111,7 @@ class DBUtils:
     @staticmethod
     def update_one_by_id(
         collection: DBCollection,
-        docid: str,
+        docid: str | ObjectId,
         field_to_value: dict,
         session: ClientSession | None = None,
     ) -> bool:
@@ -142,7 +142,7 @@ class DBUtils:
 
     @staticmethod
     def delete_one_by_id(
-        collection: DBCollection, docid: str, session: ClientSession = None
+        collection: DBCollection, docid: str | ObjectId, session: ClientSession = None
     ) -> bool:
         """
         Delete one document with the given ID

--- a/backend/src/impl/db_utils/system_db_utils.py
+++ b/backend/src/impl/db_utils/system_db_utils.py
@@ -227,6 +227,7 @@ class SystemDBUtils:
             system["creator"] = user.id
             system["preferred_username"] = user.preferred_username
             system["created_at"] = system["last_modified"] = datetime.utcnow()
+            system["system_id"] = str(ObjectId())
 
             if metadata.dataset_metadata_id:
                 if not metadata.dataset_split:


### PR DESCRIPTION
We have been using MongoDB's mechanism to generate system IDs on insert. This is not ideal because it requires us to execute operations in a certain order (e.g. we don't know the system ID until it is actually created in the DB). We also had to use `None` as a hacky placeholder for `system_id` before the record is inserted into the DB (it is also not type-correct). This is error-prone because if the developer doesn't know this context, they may access `system_id` before it holds the actual value.

This PR fixes this issue by pre-generating the id for the system so `system_id` is always accessible.