### PR TITLE
add trend property for benchmark plots

### DIFF
--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -227,17 +227,17 @@ def benchmark_get_by_id(benchmark_id: str, by_creator: bool) -> Benchmark:
     plot_dict = BenchmarkDBUtils.generate_plots(benchmark_id)
     views = []
     for k, v in view_dict.items():
+        v_df = pd.DataFrame.from_dict(v)
         if by_creator:
             col_name = "creator"
         elif k == "Most-underserved Languages":
             col_name = "source_language"
         else:
-            col_name = "system_name"
-        views.append(
-            BenchmarkDBUtils.dataframe_to_table(
-                k, pd.DataFrame.from_dict(v), plot_dict, col_name
-            )
-        )
+            columns = v_df.columns
+            # If the df is not grouped by system_name,
+            # choose one as the primary column
+            col_name = "system_name" if "system_name" in columns else columns[0]
+        views.append(BenchmarkDBUtils.dataframe_to_table(k, v_df, plot_dict, col_name))
     return Benchmark(config, views, update_time)
 
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.23"
+  version: "0.2.24"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -1398,6 +1398,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BenchmarkOperationConfig'
+        trend:
+          type: string
+          nullable: true
 
     BenchmarkDatasetConfig:
       type: object


### PR DESCRIPTION
## Benchmark plot: show datapoints for every date

Add a new property `trend` in BenchmarkViewConfig. 
`trend='all'` : show the score of every unique date 
`trend='increase'` : only show the scores and dates that are larger than the previous ones, so the plot is in ascending trend.
This property will also be useful for configuring meta analysis (e.g. setting `trend='all'` to display metadata for every unique date). 

For example, this is the views config of all the systems using sst2.
```
"views": [
        {
            "name": "Overall Mean",
            "operations": [
                {"op": "mean"}
            ],
            "trend": "all"
        },
        {
            "name": "Overall Mean Skip Group System",
            "operations": [
                {"op": "mean", "skip_group_system": true}
            ],
            "trend": "all"
        },
        {
            "name": "Mean by Dataset",
            "operations": [
                {"op": "mean", "group_by": ["dataset_name"]}
            ],
            "trend": "all"
        },
        {
            "name": "Mean by Dataset Skip Group System",
            "operations": [
                {"op": "mean", "group_by": ["dataset_name"], "skip_group_system": true}
            ],
            "trend": "all"
        }
    ]
```

The result benchmark plots are:

![Screen Shot 2022-12-05 at 5 46 48 PM](https://user-images.githubusercontent.com/71625258/205762314-683222e9-855a-4bdd-8557-8325b2864974.png)
![Screen Shot 2022-12-05 at 5 47 04 PM](https://user-images.githubusercontent.com/71625258/205762321-549796c4-f484-4
![Screen Shot 2022-12-05 at 5 47 12 PM](https://user-images.githubusercontent.com/71625258/205762326-fa85bbf7-d034-40a4-b0f4-b786b18eada3.png)
662-ac64-7d365af31ec4.png)
![Screen Shot 2022-12-05 at 5 47 19 PM](https://user-images.githubusercontent.com/71625258/205762341-b1fe181e-9d21-4f1a-b4db-f17df4596a63.png)
![Screen Shot 2022-12-05 at 5 47 39 PM](https://user-images.githubusercontent.com/71625258/205762351-5bc423a9-df42-4ed5-895f-223868cdd31c.png)
