### PR TITLE
fix length mismatch bug in FineGrainedAnalysis

### DIFF
--- a/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
+++ b/frontend/src/components/Analysis/AnalysisDrawer/index.tsx
@@ -245,7 +245,7 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
   }
 
   function renderDrawerContent(): React.ReactElement {
-    if (visible && systemAnalysesReturn) {
+    if (pageState === PageState.success && visible && systemAnalysesReturn) {
       return (
         <AnalysisReport
           task={getTask()}
@@ -262,7 +262,11 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
     }
     if (pageState === PageState.error)
       return <FallbackUI errorMessage={errorMessage} />;
-    return <div style={{ height: "50vh" }} />;
+    return (
+      <Spin spinning={pageState === PageState.loading} tip="Analyzing...">
+        <div style={{ height: "50vh" }} />
+      </Spin>
+    );
   }
 
   function downloadAnalysis() {
@@ -293,6 +297,7 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
       */
       closable={pageState !== PageState.loading}
       maskClosable={pageState !== PageState.loading}
+      destroyOnClose
       extra={
         <div>
           <DownloadAnalysisButton
@@ -310,9 +315,7 @@ export function AnalysisDrawer({ systems, closeDrawer }: Props) {
         We use an error boundary component and provide a fall back UI if an error is caught.
       */}
       <ErrorBoundary fallbackUI={<FallbackUI errorMessage={errorMessage} />}>
-        <Spin spinning={pageState === PageState.loading} tip="Analyzing...">
-          {renderDrawerContent()}
-        </Spin>
+        {renderDrawerContent()}
       </ErrorBoundary>
     </Drawer>
   );

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/FineGrainedBarChart.tsx
@@ -31,6 +31,13 @@ export function FineGrainedBarChart(props: Props) {
     onBarClick,
     addChartFile,
   } = props;
+
+  if (systems.length !== results.length) {
+    console.error(
+      `systems and results should be the same length ${systems.length}!=${results.length}`
+    );
+  }
+
   // For invariant variables across all systems, we can simply take from the first result
   function getSystemNames(systems: SystemModel[]) {
     const systemNames = systems.map((sys) => sys.system_name);


### PR DESCRIPTION
closes #549 

This bug has existed for a long time but it is made more visible in #504.

### The bug
`<FineGrainedBarChart />` takes `systems` and `results` as props. Whenever the user clicks on "Analysis", `systems` get updated immediately. `results` requires another API call so there is a delay in updating its value. The two props aren't always compatible because of that delay. 

### The fix
In `<AnalysisDrawer />` (parent component of `<FineGrainedBarChart />`), we wait until `results` is updated (indicated by `pageState === PageState.success`) before we render `<FineGrainedBarChart />`. I also added validation in `<FineGrainedBarChart />` which logs an error if the two props are not the same length.

I also added `destroyOnClose` to `<AnlysisDrawer />` which destroys all the states held by `<AnalysisDrawer />` when it is closed. This means all the states get reset to their initial values for every analysis. This is less efficient but it makes it easier to manage states. For example, if `<AnalysisDrawer />` gets into an error state, there is no way of recovering from that at the moment. After the change, the user can recover from such an error state by closing the drawer and reanalyze.