### PR TITLE
Benchmark submit drawer and delete button

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "react-ga4": "^1.4.1",
         "react-helmet": "^6.1.0",
         "react-router-dom": "^5.3.0",
+        "react-textarea-autosize": "^8.4.0",
         "typescript": "^4.4.3",
         "web-vitals": "^1.1.2"
       },
@@ -45,6 +46,7 @@
         "eslint-plugin-react": "^7.26.0",
         "lint-staged": "11.1.2",
         "prettier": "^2.4.1",
+        "raw-loader": "^4.0.2",
         "react-scripts": "4.0.3"
       }
     },
@@ -20156,6 +20158,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/raw-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/rc-align": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.11.tgz",
@@ -21104,6 +21144,59 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-textarea-autosize/node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-textarea-autosize/node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize/node_modules/use-latest/node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/readable-stream": {
@@ -42277,6 +42370,29 @@
         }
       }
     },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "rc-align": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.11.tgz",
@@ -42994,6 +43110,40 @@
         "lowlight": "^1.14.0",
         "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
+      }
+    },
+    "react-textarea-autosize": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "dependencies": {
+        "use-composed-ref": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+          "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+          "requires": {}
+        },
+        "use-latest": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+          "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+          "requires": {
+            "use-isomorphic-layout-effect": "^1.1.1"
+          },
+          "dependencies": {
+            "use-isomorphic-layout-effect": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+              "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+              "requires": {}
+            }
+          }
+        }
       }
     },
     "readable-stream": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,6 @@
         "react-helmet": "^6.1.0",
         "react-router-dom": "^5.3.0",
         "react-simple-code-editor": "^0.13.1",
-        "react-textarea-autosize": "^8.4.0",
         "typescript": "^4.4.3",
         "web-vitals": "^1.1.2"
       },
@@ -21154,59 +21153,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-textarea-autosize/node_modules/use-composed-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-textarea-autosize/node_modules/use-latest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-textarea-autosize/node_modules/use-latest/node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/readable-stream": {
@@ -43126,40 +43072,6 @@
         "lowlight": "^1.14.0",
         "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
-      }
-    },
-    "react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "dependencies": {
-        "use-composed-ref": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-          "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-          "requires": {}
-        },
-        "use-latest": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-          "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
-          "requires": {
-            "use-isomorphic-layout-effect": "^1.1.1"
-          },
-          "dependencies": {
-            "use-isomorphic-layout-effect": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-              "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-              "requires": {}
-            }
-          }
-        }
       }
     },
     "readable-stream": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "react-ga4": "^1.4.1",
         "react-helmet": "^6.1.0",
         "react-router-dom": "^5.3.0",
+        "react-simple-code-editor": "^0.13.1",
         "react-textarea-autosize": "^8.4.0",
         "typescript": "^4.4.3",
         "web-vitals": "^1.1.2"
@@ -21129,6 +21130,15 @@
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-simple-code-editor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz",
+      "integrity": "sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/react-syntax-highlighter": {
@@ -43098,6 +43108,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "requires": {}
+    },
+    "react-simple-code-editor": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz",
+      "integrity": "sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==",
       "requires": {}
     },
     "react-syntax-highlighter": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.3.0",
     "react-simple-code-editor": "^0.13.1",
-    "react-textarea-autosize": "^8.4.0",
     "typescript": "^4.4.3",
     "web-vitals": "^1.1.2"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "react-ga4": "^1.4.1",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.3.0",
+    "react-textarea-autosize": "^8.4.0",
     "typescript": "^4.4.3",
     "web-vitals": "^1.1.2"
   },
@@ -74,6 +75,7 @@
     "eslint-plugin-react": "^7.26.0",
     "lint-staged": "11.1.2",
     "prettier": "^2.4.1",
+    "raw-loader": "^4.0.2",
     "react-scripts": "4.0.3"
   },
   "overrides": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "react-ga4": "^1.4.1",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.3.0",
+    "react-simple-code-editor": "^0.13.1",
     "react-textarea-autosize": "^8.4.0",
     "typescript": "^4.4.3",
     "web-vitals": "^1.1.2"

--- a/frontend/src/components/BenchmarkCards/index.tsx
+++ b/frontend/src/components/BenchmarkCards/index.tsx
@@ -1,11 +1,24 @@
 import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import "./index.css";
-import { Card, Col, PageHeader, Row, Typography, Space } from "antd";
+import {
+  Card,
+  Col,
+  PageHeader,
+  Row,
+  Typography,
+  Space,
+  Popconfirm,
+  Button,
+  message,
+} from "antd";
 import { BenchmarkConfig } from "../../clients/openapi";
 import { Helmet } from "react-helmet";
 import { NewResourceButton } from "../../components/Button";
 import { BenchmarkSubmitDrawer } from "../BenchmarkSubmitDrawer";
+import { backendClient, parseBackendError } from "../../clients";
+import { DeleteOutlined } from "@ant-design/icons";
+import { useUser } from "../useUser";
 
 interface Props {
   items: Array<BenchmarkConfig>;
@@ -13,9 +26,21 @@ interface Props {
 }
 
 export function BenchmarkCards({ items, subtitle }: Props) {
+  const { userInfo } = useUser();
   const history = useHistory();
-  const { Title } = Typography;
   const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);
+
+  async function deleteBenchmark(benchmarkID: string) {
+    try {
+      await backendClient.benchmarkDeleteById(benchmarkID);
+      message.success("Success");
+      document.location.reload();
+    } catch (e) {
+      if (e instanceof Response) {
+        message.error((await parseBackendError(e)).getErrorMsg());
+      }
+    }
+  }
 
   function showSubmitDrawer() {
     setSubmitDrawerVisible(true);
@@ -40,28 +65,56 @@ export function BenchmarkCards({ items, subtitle }: Props) {
         </Space>
       </Row>
       <Row gutter={[16, 16]}>
-        {items.map((config) => (
-          <Col key={config.id} span={6}>
-            <Card
-              hoverable
-              style={{
-                width: 240,
-              }}
-              className="benchmark-card"
-              title={
-                <div style={{ textAlign: "center" }}>
-                  <Title level={3}>{config.name}</Title>
-                </div>
-              }
-              onClick={() =>
-                history.push(`${document.location.pathname}?id=${config.id}`)
-              }
-              cover={
-                <img alt="example" style={{ height: 200 }} src={config.logo} />
-              }
-            ></Card>
-          </Col>
-        ))}
+        {items.map((config) => {
+          const notCreator = config.creator !== userInfo?.id;
+          return (
+            <Col key={config.id} span={6}>
+              <Card
+                hoverable
+                style={{
+                  width: 240,
+                }}
+                className="benchmark-card"
+                title={
+                  <div style={{ textAlign: "center" }}>
+                    <Typography.Title level={3}>{config.name}</Typography.Title>
+                  </div>
+                }
+                onClick={() =>
+                  history.push(`${document.location.pathname}?id=${config.id}`)
+                }
+                cover={
+                  <img
+                    alt="example"
+                    style={{ height: 200 }}
+                    src={config.logo}
+                  />
+                }
+              >
+                <Row justify="end">
+                  <Popconfirm
+                    disabled={notCreator}
+                    title="Are you sure?"
+                    onConfirm={(e) => {
+                      e?.stopPropagation();
+                      deleteBenchmark(config.id);
+                    }}
+                  >
+                    <Button
+                      danger
+                      disabled={notCreator}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                      }}
+                      size="small"
+                      icon={<DeleteOutlined />}
+                    />
+                  </Popconfirm>
+                </Row>
+              </Card>
+            </Col>
+          );
+        })}
       </Row>
       <BenchmarkSubmitDrawer
         visible={submitDrawerVisible}

--- a/frontend/src/components/BenchmarkCards/index.tsx
+++ b/frontend/src/components/BenchmarkCards/index.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import "./index.css";
-import { Card, Col, PageHeader, Row, Typography } from "antd";
+import { Card, Col, PageHeader, Row, Typography, Space } from "antd";
 import { BenchmarkConfig } from "../../clients/openapi";
 import { Helmet } from "react-helmet";
+import { NewResourceButton } from "../../components/Button";
+import { BenchmarkSubmitDrawer } from "../BenchmarkSubmitDrawer";
 
 interface Props {
   items: Array<BenchmarkConfig>;
@@ -13,6 +15,11 @@ interface Props {
 export function BenchmarkCards({ items, subtitle }: Props) {
   const history = useHistory();
   const { Title } = Typography;
+  const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);
+
+  function showSubmitDrawer() {
+    setSubmitDrawerVisible(true);
+  }
 
   return (
     <div className="page">
@@ -24,7 +31,15 @@ export function BenchmarkCards({ items, subtitle }: Props) {
         title="Benchmarks"
         subTitle={subtitle}
       />
-      <Row gutter={[16, 16]} className="benchmarks-grid">
+      <Row justify="end">
+        <Space style={{ width: "fit-content", float: "right" }}>
+          <NewResourceButton
+            onClick={showSubmitDrawer}
+            resourceName="benchmark"
+          />
+        </Space>
+      </Row>
+      <Row gutter={[16, 16]}>
         {items.map((config) => (
           <Col key={config.id} span={6}>
             <Card
@@ -38,20 +53,22 @@ export function BenchmarkCards({ items, subtitle }: Props) {
                   <Title level={3}>{config.name}</Title>
                 </div>
               }
-              // title= {< div style= {{textAlign: "center"}} > Card title </div >}
-
               onClick={() =>
                 history.push(`${document.location.pathname}?id=${config.id}`)
               }
               cover={
                 <img alt="example" style={{ height: 200 }} src={config.logo} />
               }
-            >
-              {/* {name} */}
-            </Card>
+            ></Card>
           </Col>
         ))}
       </Row>
+      <BenchmarkSubmitDrawer
+        visible={submitDrawerVisible}
+        onClose={() => {
+          setSubmitDrawerVisible(false);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/BenchmarkSubmitDrawer/benchmark_config.js
+++ b/frontend/src/components/BenchmarkSubmitDrawer/benchmark_config.js
@@ -1,8 +1,5 @@
-// Please remove
-// 1. "const benchmark_config = "
-// 2. all comments (lines prefixed with "//")
+// Please remove all comments (lines starting with "//")
 // before submitting as they are not allowed in JSON
-//
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 const benchmark_config = {
   // == REQUIRED FIELDS ==

--- a/frontend/src/components/BenchmarkSubmitDrawer/benchmark_config.js
+++ b/frontend/src/components/BenchmarkSubmitDrawer/benchmark_config.js
@@ -1,0 +1,70 @@
+// Please remove
+// 1. "const benchmark_config = "
+// 2. all comments (lines prefixed with "//")
+// before submitting as they are not allowed in JSON
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+const benchmark_config = {
+  // == REQUIRED FIELDS ==
+  id: "example",
+  is_private: false,
+  shared_users: ["example@gmail.com"],
+  name: "Example Benchmark",
+  // A parent benchmark id that this benchmark inherits config from.
+  // If this benchmark doesn't inherit any configs,
+  // the field must be an empty string
+  parent: "",
+  description: "Example Description",
+  // == POTENTIALLY REQUIRED FIELDS ==
+  // "views" is required if "parent" is an empty string
+  views: [
+    {
+      name: "Example View",
+      operations: [{ op: "mean", group_by: ["sub_dataset"] }],
+    },
+  ],
+  // == OPTIONAL FIELDS ==
+  // Specify "abstract" to indicate this doesn't
+  // fully specify a benchmark
+  type: "abstract",
+  // Please contact us and send us your logo.
+  // We will add it to our image store and update the link.
+  logo: "",
+  contact: "example@gmail.com",
+  homepage: "https://example.com",
+  paper: {
+    // REQUIRED if paper is not None
+    title: "Example Paper",
+    url: "www.example.com",
+  },
+  metrics: [
+    {
+      // REQUIRED for each metrics element
+      name: "ExampleMetric",
+      // OPTIONAL
+      weight: 1.0,
+      default: 1.0,
+    },
+  ],
+  datasets: [
+    {
+      // REQUIRED for each datasets element
+      dataset_name: "example_dataset",
+      // OPTIONAL
+      sub_dataset: "example_sub_dataset",
+      split: "test",
+      metrics: [
+        {
+          // REQUIRED for each metrics element
+          name: "ExampleMetric",
+          // OPTIONAL
+          weight: 1.0,
+          default: 1.0,
+        },
+      ],
+    },
+  ],
+  system_query: {
+    task_name: "example-task",
+  },
+  default_views: ["Example View"],
+};

--- a/frontend/src/components/BenchmarkSubmitDrawer/benchmark_config.js
+++ b/frontend/src/components/BenchmarkSubmitDrawer/benchmark_config.js
@@ -2,6 +2,7 @@
 // 1. "const benchmark_config = "
 // 2. all comments (lines prefixed with "//")
 // before submitting as they are not allowed in JSON
+//
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 const benchmark_config = {
   // == REQUIRED FIELDS ==

--- a/frontend/src/components/BenchmarkSubmitDrawer/index.css
+++ b/frontend/src/components/BenchmarkSubmitDrawer/index.css
@@ -1,5 +1,5 @@
 /* Forcefully apply the same style used in react-code-blocks to align the style of
-text area with that of react-code-blocks. */
+textarea in react-simple-code-editor with that of react-code-blocks. */
 #benchmark-submit-drawer-text-area {
   padding: 8px !important;
   line-height: 1.66667 !important;
@@ -20,7 +20,7 @@ during selection. */
   -webkit-text-fill-color: #fff !important;
 }
 
-/* Forcefully apply the style used in react-code-blocks. */
+/* Forcefully re-apply the style used in react-code-blocks as it got overwritten. */
 .benchmark-submit-drawer-pre {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace !important;

--- a/frontend/src/components/BenchmarkSubmitDrawer/index.css
+++ b/frontend/src/components/BenchmarkSubmitDrawer/index.css
@@ -1,0 +1,29 @@
+/* Forcefully apply the same style used in react-code-blocks to align the style of
+text area with that of react-code-blocks. */
+#benchmark-submit-drawer-text-area {
+  padding: 8px !important;
+  line-height: 1.66667 !important;
+  overflow-x: auto !important;
+  caret-color: #fff !important;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace !important;
+}
+
+/*
+react-simple-code-editor sets the text color in text-area to be transparent, but
+this makes them invisible when selected (e.g., highlighting using a cursor).
+We forcefully apply the styles below to make them appear as white
+during selection.
+*/
+::selection {
+  -webkit-text-fill-color: #fff !important;
+}
+::-moz-selection {
+  -webkit-text-fill-color: #fff !important;
+}
+
+/* Forcefully apply the style used in react-code-blocks. */
+.benchmark-submit-drawer-pre {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace !important;
+}

--- a/frontend/src/components/BenchmarkSubmitDrawer/index.css
+++ b/frontend/src/components/BenchmarkSubmitDrawer/index.css
@@ -9,12 +9,10 @@ text area with that of react-code-blocks. */
     monospace !important;
 }
 
-/*
-react-simple-code-editor sets the text color in text-area to be transparent, but
+/* react-simple-code-editor sets the text color in text-area to be transparent, but
 this makes them invisible when selected (e.g., highlighting using a cursor).
 We forcefully apply the styles below to make them appear as white
-during selection.
-*/
+during selection. */
 ::selection {
   -webkit-text-fill-color: #fff !important;
 }

--- a/frontend/src/components/BenchmarkSubmitDrawer/index.tsx
+++ b/frontend/src/components/BenchmarkSubmitDrawer/index.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from "react";
+import {
+  Drawer,
+  message,
+  DrawerProps,
+  Space,
+  Button,
+  Spin,
+  Row,
+  Col,
+} from "antd";
+import { CodeBlock, dracula } from "react-code-blocks";
+import TextareaAutosize from "react-textarea-autosize";
+import ReactGA from "react-ga4";
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import benchmarkConfigString from "raw-loader!./benchmark_config.js";
+import { backendClient, parseBackendError } from "../../clients";
+
+interface Props extends DrawerProps {
+  onClose: () => void;
+  visible: boolean;
+}
+
+enum State {
+  loading,
+  other,
+}
+
+export function BenchmarkSubmitDrawer(props: Props) {
+  const [state, setState] = useState(State.other);
+  const [input, setInput] = useState(benchmarkConfigString);
+
+  const { onClose, visible, ...rest } = props;
+
+  async function submit() {
+    try {
+      setState(State.loading);
+      const benchmark = await backendClient.benchmarkPost(JSON.parse(input));
+      ReactGA.event({
+        category: "Benchmark",
+        action: `benchmark_submit_success`,
+      });
+      message.success(`Successfully submitted benchmark (${benchmark.id})}).`);
+      setInput(benchmarkConfigString);
+      onClose();
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        message.error(e.message);
+      } else if (e instanceof Response) {
+        const err = await parseBackendError(e);
+        message.error(err.getErrorMsg());
+      } else {
+        console.error(e);
+        message.error("[InternalError] Please contact admin");
+      }
+    } finally {
+      setState(State.other);
+    }
+  }
+
+  const footer = (
+    <Space>
+      <Button
+        type="primary"
+        onClick={() => submit()}
+        loading={state === State.loading}
+      >
+        Submit
+      </Button>
+      <Button onClick={() => onClose()} loading={state === State.loading}>
+        Cancel
+      </Button>
+    </Space>
+  );
+
+  return (
+    <Drawer
+      title={"New Benchmark"}
+      footer={footer}
+      onClose={onClose}
+      visible={visible}
+      width="86%"
+      {...rest}
+    >
+      <Spin spinning={state === State.loading} tip="processing...">
+        <Row gutter={[16, 16]}>
+          <Col span={12}>Editor</Col>
+          <Col span={12}>Preview</Col>
+        </Row>
+        <Row gutter={[16, 16]}>
+          <Col span={12}>
+            <TextareaAutosize
+              // this style is required to align the lines of code in textarea with
+              // with those in code block
+              style={{
+                width: "100%",
+                lineHeight: 1.66667,
+                paddingTop: "8px",
+              }}
+              rows={benchmarkConfigString.split("\n").length}
+              value={input}
+              onChange={(e) => setInput(e.currentTarget.value)}
+            />
+          </Col>
+          <Col span={12}>
+            <CodeBlock
+              text={input}
+              language="json"
+              theme={dracula}
+              showLineNumbers={false}
+            />
+          </Col>
+        </Row>
+      </Spin>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/BenchmarkSubmitDrawer/index.tsx
+++ b/frontend/src/components/BenchmarkSubmitDrawer/index.tsx
@@ -117,6 +117,8 @@ export function BenchmarkSubmitDrawer(props: Props) {
                   theme={dracula}
                   showLineNumbers={false}
                   customStyle={{
+                    /* This style helps align react-code-blocks
+                    with react-simple-code-editor. */
                     whiteSpace: "pre-wrap",
                     overflowWrap: "anywhere",
                   }}

--- a/frontend/src/components/BenchmarkSubmitDrawer/index.tsx
+++ b/frontend/src/components/BenchmarkSubmitDrawer/index.tsx
@@ -41,7 +41,7 @@ export function BenchmarkSubmitDrawer(props: Props) {
         category: "Benchmark",
         action: `benchmark_submit_success`,
       });
-      message.success(`Successfully submitted benchmark (${benchmark.id})}).`);
+      message.success(`Successfully submitted benchmark (${benchmark.id})).`);
       setInput(benchmarkConfigString);
       onClose();
     } catch (e) {

--- a/frontend/src/components/Button/index.tsx
+++ b/frontend/src/components/Button/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Button, ButtonProps, Tooltip } from "antd";
+import { LoginState, useUser } from "../useUser";
+import { capitalizeFirstLetter } from "../../utils/index";
+
+interface Props extends ButtonProps {
+  resourceName: string;
+}
+
+export function NewResourceButton(props: Props) {
+  const { login, state } = useUser();
+  const { resourceName, ...rest } = props;
+  const capitalizedResourceName = capitalizeFirstLetter(resourceName);
+  if (state === LoginState.yes)
+    return (
+      <Button
+        style={{ backgroundColor: "#28a745", borderColor: "#28a745" }}
+        type="primary"
+        {...rest}
+      >
+        {`Submit New ${capitalizedResourceName}`}
+      </Button>
+    );
+  return (
+    <Tooltip
+      title={`Please sign in to submit new ${resourceName}s`}
+      placement="topLeft"
+      defaultVisible
+    >
+      <Button
+        onClick={login}
+        style={{ borderColor: "#28a745", color: "#28a745" }}
+      >
+        {`Submit New ${capitalizedResourceName}`}
+      </Button>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/SystemsTable/SystemTableTools.tsx
+++ b/frontend/src/components/SystemsTable/SystemTableTools.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {
   Button,
-  ButtonProps,
   Input,
   Select,
   Space,
@@ -20,6 +19,7 @@ import { SystemModel } from "../../models";
 import { LoginState, useUser } from "../useUser";
 import { backendClient, parseBackendError } from "../../clients";
 import { FilterUpdate, SystemFilter } from "./SystemFilter";
+import { NewResourceButton } from "../Button";
 
 interface Props {
   systems: SystemModel[];
@@ -254,36 +254,8 @@ export function SystemTableTools({
           style={{ minWidth: "120px" }}
         />
 
-        <NewSystemButton onClick={showSubmitDrawer} />
+        <NewResourceButton onClick={showSubmitDrawer} resourceName="system" />
       </Space>
     </div>
-  );
-}
-
-function NewSystemButton(props: ButtonProps) {
-  const { login, state } = useUser();
-  if (state === LoginState.yes)
-    return (
-      <Button
-        style={{ backgroundColor: "#28a745", borderColor: "#28a745" }}
-        type="primary"
-        {...props}
-      >
-        Submit New System
-      </Button>
-    );
-  return (
-    <Tooltip
-      title="Please sign in to submit new systems"
-      placement="topLeft"
-      defaultVisible
-    >
-      <Button
-        onClick={login}
-        style={{ borderColor: "#28a745", color: "#28a745" }}
-      >
-        Submit New System
-      </Button>
-    </Tooltip>
   );
 }

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -3,3 +3,8 @@ declare module "*.yaml" {
   const data: string;
   export default data;
 }
+
+declare module "raw-loader!*" {
+  const data: string;
+  export default data;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -50,4 +50,8 @@ export function generateLeaderboardURL(
   return url;
 }
 
+export function capitalizeFirstLetter(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
 export * from "./typing_utils";


### PR DESCRIPTION
This PR adds the functionality to submit and delete benchmarks via the web interface.

### Submit Button and Drawer
The submit button is placed at the top right of the benchmark page. We can improve its layout in a future PR.
<img width="1248" alt="Screen Shot 2022-12-13 at 2 29 46 PM" src="https://user-images.githubusercontent.com/30998659/207427128-8a0f40d8-cc39-4f79-b958-1751cf068f5e.png">

A drawer opens when the submit button is clicked (just like submitting a new system). After some research, I managed to create a single editor window that users can directly interact with. The editor supports some handy functionalities like indenting selected lines by pressing the tab key and automatic indent on new lines.

This is achieved by combining our existing dependency `react-code-blocks` with a new package [react-simple-code-editor](https://github.com/react-simple-code-editor/react-simple-code-editor). The new package has [a high download count in npm](https://www.npmjs.com/package/react-simple-code-editor) and a moderate maintenance frequency. The reason why I did not choose `react-textarea-code-editor` is I find its "undo" command buggy (you can try hitting a couple of enters in this [official demo](https://codesandbox.io/embed/react-textarea-code-editor-for-example-mcebp?fontsize=14&hidenavigation=1&theme=dark) and undo to reproduce). 

I also tried to remove `react-code-blocks` and rely only on `react-simple-code-editor`, but it gets a bit complicated as we need to install a new syntax highlighting package `prismjs`. It will take some effort to import it and use it in our code, so I think it I think we can explore it in a future PR. We'll also need to manually support the "copy code" functionality provided by `react-code-blocks`, but that shouldn't be too hard.

I'd also love to take the chance to briefly explain how the editor functionality is created. So please bear with me a bit haha. 

Many if not all editor packages actually use the same strategy, which is overlaying an **invisible editable textbox** on top of **highlighted text**. The reason for doing so is the text inside the "editable textbox" (which I'll refer to as "textarea" from now on because that's the HTML element used under the hood) cannot be highlighted due to fundamental constraints. This means they must duplicate the text, highlight and enclose it in another HTML element (which I'll refer to as "pre" from now on as that's the element used under the hood). So textarea and pre have the exact same text, except the former being editable and the latter highlighted.

Now the clever part is to make "textarea" invisible and overlay text on top of "pre", so the character position matches perfectly. This creates the illusion that we are editing on highlighted text, but in reality we are editing on invisible text that gets rehighlighted and rendered beneath our text box.

In my implementation, `react-code-blocks` acts as "pre", and react-simple-code-editor` provides the "textarea" with handy editor functionalities. While I needed to write some explicit CSS to align them together and fix small style issues, there isn't too much overhead and complexity. Open to comments and suggestions!

<img width="706" alt="Screen Shot 2022-12-13 at 2 25 14 PM" src="https://user-images.githubusercontent.com/30998659/207427014-a8075d87-a2e9-45f1-87bc-d9f6b0fb8fd4.png">

### Delete Button
The delete button is placed at the bottom right of the benchmark card and is disabled for users who are not the owner of the benchmark.
<img width="305" alt="Screen Shot 2022-12-13 at 2 26 43 PM" src="https://user-images.githubusercontent.com/30998659/207426922-add792a4-5238-4111-9c62-efb3d74ff85a.png">

