### PR TITLE
add upload file examples

### DIFF
--- a/frontend/src/components/SystemSubmitDrawer/CustomDatasetFileFormats.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/CustomDatasetFileFormats.tsx
@@ -1,0 +1,186 @@
+export interface FileTypeToTaskExample {
+  [key: string]: TaskExample;
+}
+
+interface TaskExample {
+  [key: string]: string;
+}
+
+export const customDatasetExamplesMap: {
+  [key: string]: FileTypeToTaskExample;
+} = {};
+customDatasetExamplesMap["machine-translation"] = {
+  tsv: {
+    example: `This is a good movie    这是一部好电影
+...`,
+    description: `"source" and "reference" separated by tab`,
+  },
+  json: {
+    example: `[
+    {"source": "This is a good movie", "reference": "这是一部好电影"},
+    ...
+]`,
+    description: `a list of dictionaries with two keys: "source" and "reference"`,
+  },
+};
+
+customDatasetExamplesMap["summarization"] = {
+  tsv: {
+    example: `This is a good movie    这是一部好电影
+...`,
+    description: `"source" and "reference" separated by tab`,
+  },
+  json: {
+    example: `[
+    {"source": "This is a good movie", "reference": "这是一部好电影"},
+    ...
+]`,
+    description: `a list of dictionaries with two keys: "source" and "reference"`,
+  },
+};
+
+customDatasetExamplesMap["conditional-generation"] = {
+  tsv: {
+    example: `This is a good movie    这是一部好电影
+...`,
+    description: `"source" and "reference" separated by tab`,
+  },
+  json: {
+    example: `[
+    {"source": "This is a good movie", "reference": "这是一部好电影"},
+    ...
+]`,
+    description: `a list of dictionaries with two keys: "source" and "reference"`,
+  },
+};
+
+customDatasetExamplesMap["text-classification"] = {
+  tsv: {
+    example: `I love this movie   positive
+The movie is too long   negative
+...`,
+    description: `"text" and "true_label" separated by tab`,
+  },
+  json: {
+    example: `[
+    {"text": "I love this movie", "true_label": "positive"},
+    {"text": "The movie is too long", "true_label": "negative"}
+    ...
+]`,
+    description: `a list of dictionaries with two keys: "text" and "true_label"`,
+  },
+};
+
+customDatasetExamplesMap["named-entity-recognition"] = {
+  conll: {
+    example: `Barack	B-PER
+Obama	I-PER
+
+I	O
+love	O
+America	B-LOC`,
+    description: `"word" and "label" separated by tab. There should be an empty line between each sentence.`,
+  },
+};
+
+customDatasetExamplesMap["chunking"] = {
+  conll: {
+    example: `Manville	B-NP
+is	B-VP
+a	B-NP
+forest	I-NP
+products	I-NP
+concern	I-NP
+.	O
+
+Percival	B-NP
+declined	B-VP
+to	I-VP
+comment	I-VP
+.	O`,
+    description: `"word" and "label" separated by tab. There should be an empty line between each sentence.`,
+  },
+};
+
+customDatasetExamplesMap["qa-extractive"] = {
+  json: {
+    example: `[
+    {"context": "Super Bowl 50 was an American footb",
+    "question": "Which NFL team represented the AFC at Super Bowl 50?",
+    "answers": {'text': ['Denver Broncos', 'Denver Broncos', 'Denver Broncos'], 'answer_start': [177, 177, 177]}},
+    ...
+]`,
+    description: `a list of dictionaries with three keys: "context", "question", and "answers"`,
+  },
+};
+
+customDatasetExamplesMap["qa-multiple-choice"] = {
+  json: {
+    example: `[
+    {'context': 'The girl had the flightiness of a sparrow',
+    'question': '',
+    'answers': {'text': 'The girl was very fickle.', 'option_index': 0},
+    'options': ['The girl was very fickle.', 'The girl was very stable.']},
+    ...
+]`,
+    description: `a list of dictionaries with four keys: "context" , "options", "question", and "answers"`,
+  },
+};
+
+customDatasetExamplesMap["qa-open-domain"] = {
+  json: {
+    example: `[
+    {'question': 'who got the first nobel prize in physics',
+    'answers': ['Wilhelm Conrad Röntgen']},
+    ...
+]`,
+    description: `a list of dictionaries with two keys: "question" and "answers"`,
+  },
+};
+
+customDatasetExamplesMap["aspect-based-sentiment-classification"] = {
+  tsv: {
+    example: `use	It's fast, light, and simple to use.	positive
+Windows 8	Lastly, Windows 8 is annoying.	negative`,
+    description: `"aspect", "sentence", and "polarity" separated by tab`,
+  },
+};
+
+customDatasetExamplesMap["aspect-based-sentiment-classification"] = {
+  tsv: {
+    example: `use	It's fast, light, and simple to use.	positive
+Windows 8	Lastly, Windows 8 is annoying.	negative`,
+    description: `"aspect", "sentence", and "polarity" separated by tab`,
+  },
+};
+
+customDatasetExamplesMap["text-pair-classification"] = {
+  tsv: {
+    example: `A man playing an electric guitar on stage.   A man playing banjo on the floor.  contradiction
+A man playing an electric guitar on stage.   A man is performing for cash.  neutral
+...`,
+    description: `"text1", "text2", and "true_label" separated by tab`,
+  },
+  json: {
+    example: `[
+    {"text1": "A man playing an electric guitar on stage.",
+    "text2": "A man playing banjo on the floor.",
+    "true_label": "contradiction"},
+    {"text1": "A man playing an electric guitar on stage.",
+    "text2": "A man is performing for cash.",
+    "true_label": "neutral"},
+...
+]`,
+    description: `a list of dictionaries with three keys: "text1", "text2" and "true_label"`,
+  },
+};
+
+customDatasetExamplesMap["kg-link-tail-prediction"] = {
+  json: {
+    example: `[
+    {"gold_head": "abc", "gold_predicate": "dummy relation", "gold_tail":"cde"},
+    ...
+]`,
+    description: `it's a list of dictionaries with three keys: "gold_head", "gold_predicate", and "gold_tail"`,
+  },
+};

--- a/frontend/src/components/SystemSubmitDrawer/SystemOutputFileFormats.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/SystemOutputFileFormats.tsx
@@ -1,0 +1,211 @@
+import { FileTypeToTaskExample } from "./CustomDatasetFileFormats";
+
+export const systemOutputExamplesMap: { [key: string]: FileTypeToTaskExample } =
+  {};
+systemOutputExamplesMap["machine-translation"] = {
+  text: {
+    example: `predicted_output_text
+...`,
+    description: `a predicted output per line`,
+  },
+  json: {
+    example: `[
+    {"hypothesis": "这是一部好电影"},
+    ...
+]`,
+    description: `a list of dictionaries with one key: "hypothesis"`,
+  },
+};
+
+systemOutputExamplesMap["summarization"] = {
+  text: {
+    example: `predicted_output_text
+  ...`,
+    description: `a predicted output per line`,
+  },
+  json: {
+    example: `[
+      {"hypothesis": "这是一部好电影"},
+      ...
+  ]`,
+    description: `a list of dictionaries with one key: "hypothesis"`,
+  },
+};
+
+systemOutputExamplesMap["conditional-generation"] = {
+  text: {
+    example: `predicted_output_text
+  ...`,
+    description: `a predicted output per line`,
+  },
+  json: {
+    example: `[
+      {"hypothesis": "这是一部好电影"},
+      ...
+  ]`,
+    description: `a list of dictionaries with one key: "hypothesis"`,
+  },
+};
+
+systemOutputExamplesMap["text-classification"] = {
+  text: {
+    example: `predicted_label`,
+    description: `one predicted label per line`,
+  },
+  json: {
+    example: `[
+    {"predicted_label": "positive"},
+    {"predicted_label": "negative"},
+    ...
+]`,
+    description: `a list of dictionaries with one key: "predicted_label"`,
+  },
+};
+
+systemOutputExamplesMap["named-entity-recognition"] = {
+  conll: {
+    example: `Barack	B-PER
+Obama	I-PER
+
+I	O
+love	O
+America	B-LOC`,
+    description:
+      `"word" and "predicted_label" separated by tab. There ` +
+      `should be an empty line between each sentence.`,
+  },
+};
+
+systemOutputExamplesMap["chunking"] = {
+  conll: {
+    example: `Manville	B-NP
+is	B-VP
+a	B-NP
+forest	I-NP
+products	I-NP
+concern	I-NP
+.	O
+
+Percival	B-NP
+declined	B-VP
+to	I-VP
+comment	I-VP
+.	O`,
+    description:
+      `"word" and "predicted_label" separated by tab. There ` +
+      `should be an empty line between each sentence.`,
+  },
+};
+
+systemOutputExamplesMap["qa-extractive"] = {
+  json: {
+    example: `[
+    {
+        "predicted_answers": {
+            "text": "136"
+        }
+    },
+    ...
+]`,
+    description: `"predicted_answers": denotes the predicted answers`,
+  },
+};
+
+systemOutputExamplesMap["qa-multiple-choice"] = {
+  json: {
+    example: `[
+    {
+        "context": "The girl was as down-to-earth as a Michelin-starred canape",
+        "question": "",
+        "answers": {
+            "text": "The girl was not down-to-earth at all.",
+            "option_index": 0
+        },
+        "options": [
+            "The girl was not down-to-earth at all.",
+            "The girl was very down-to-earth."
+        ],
+        "predicted_answers": {
+            "text": "The girl was not down-to-earth at all.",
+            "option_index": 0
+        }
+    },
+    ...
+]`,
+    description:
+      `a list of dictionaries with five keys: "context" , "options", ` +
+      `"question", "answers" (value should have two keys: "text", ` +
+      `"option_index"), and "predicted_answers" (value should have ` +
+      `two keys: "text", "option_index")`,
+  },
+};
+
+systemOutputExamplesMap["qa-open-domain"] = {
+  text: {
+    example: `william henry bragg
+may 18, 2018
+...`,
+    description: `Each line represents one predicted answer.`,
+  },
+};
+
+systemOutputExamplesMap["aspect-based-sentiment-classification"] = {
+  tsv: {
+    example: `use	It's fast, light, and simple to use.	positive
+Windows 8	Lastly, Windows 8 is annoying.	negative`,
+    description: `"aspect", "sentence", and "polarity" separated by tab`,
+  },
+};
+
+systemOutputExamplesMap["aspect-based-sentiment-classification"] = {
+  text: {
+    example: `positive
+negative
+...`,
+    description: `predicted label on each line`,
+  },
+};
+
+systemOutputExamplesMap["text-pair-classification"] = {
+  text: {
+    example: `predicted_label
+...`,
+    description: `Each line contains one predicted label.`,
+  },
+  json: {
+    example: `[
+    {"predicted_label": "contradiction"},
+    {"predicted_label":"neutral"},
+    ...
+]`,
+    description: `a list of dictionaries with one key: "predicted_label"`,
+  },
+};
+
+systemOutputExamplesMap["kg-link-tail-prediction"] = {
+  json: {
+    example:
+      `[
+    {
+        "gold_head": "/m/08966",
+        "gold_predicate": "/travel/travel_destination/climate./` +
+      `travel/travel_destination_monthly_climate/month",
+        "gold_tail": "/m/05lf_",
+        "predict": "tail",
+        "predictions": [
+            "/m/05lf_",
+            "/m/02x_y",
+            "/m/01nv4h",
+            "/m/02l6h",
+            "/m/0kz1h"
+        ],
+        "true_rank": 1
+    },
+    ...
+]`,
+    description:
+      `a list of dictionaries with five keys: ` +
+      `"gold_head", "gold_predicate", "gold_tail", "predict", ` +
+      `and "predictions"`,
+  },
+};

--- a/frontend/src/components/SystemSubmitDrawer/index.tsx
+++ b/frontend/src/components/SystemSubmitDrawer/index.tsx
@@ -24,7 +24,7 @@ import {
 import { backendClient, parseBackendError } from "../../clients";
 import { findTask, toBase64, unwrap } from "../../utils";
 import { useForm } from "antd/lib/form/Form";
-import { TaskSelect, TextWithLink } from "..";
+import { TaskSelect } from "..";
 import { DatasetSelect, DatasetValue } from "./DatasetSelect";
 import { DataFileUpload, DataFileValue } from "./FileSelect";
 import ReactGA from "react-ga4";
@@ -576,25 +576,6 @@ export function SystemSubmitDrawer(props: Props) {
             name="task"
             label="Task"
             rules={editMode ? [] : [{ required: true }]}
-            help={
-              selectedTask && (
-                <Tooltip
-                  title={
-                    <TextWithLink
-                      text={selectedTask.description}
-                      target="_blank"
-                    />
-                  }
-                  placement="left"
-                  color="white"
-                  overlayInnerStyle={{ color: "black" }}
-                >
-                  <Button type="link" size="small" style={{ padding: 0 }}>
-                    Submission guide for {selectedTask.name}
-                  </Button>
-                </Tooltip>
-              )
-            }
             hidden={editMode}
           >
             <TaskSelect taskCategories={taskCategories} />
@@ -630,7 +611,9 @@ export function SystemSubmitDrawer(props: Props) {
                 hidden={editMode}
               >
                 <DataFileUpload
+                  taskName={selectedTaskName}
                   allowedFileTypes={allowedFileType.custom_dataset}
+                  forCustomDataset
                 />
               </Form.Item>
             </>
@@ -667,6 +650,7 @@ export function SystemSubmitDrawer(props: Props) {
             hidden={editMode}
           >
             <DataFileUpload
+              taskName={selectedTaskName}
               allowedFileTypes={allowedFileType.system_output}
               maxFileCount={10}
             />


### PR DESCRIPTION
closes #545 

This PR 
- adds tooltips for example formats. (The examples in this PR are collected from the documentations in ExplainaBoard github/docs.)
- removes the hint "Submission guideline" beneath the task dropdown.

We previously dealt with this problem by providing a link which links to our ExplainaBoard `github/docs` documentation. However, it seems like the link is not obvious enough because first-time users are still unable to find it. And second, they have to click twice and even open a second tab to see the formats.

By directly having a hover option will make it more direct and hopefully solves the confusion.

### Tooltip with Format Example
![截圖 2022-12-07 上午12 27 21](https://user-images.githubusercontent.com/36850051/206096017-cb9e7071-4043-4727-9821-dc0a1fd0a020.png)

### Missing examples
While organizing the examples, there are still some missing examples which I opened an issue for: #558  
For these cases, this PR will not render a popover.