### PR TITLE
Improved chart layouts

### DIFF
--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/ComboAnalysisChart.tsx
@@ -112,7 +112,7 @@ export function ComboAnalysisChart(props: Props) {
       text: title,
       left: "center",
       textStyle: {
-        width: "250",
+        width: "180",
         overflow: "break",
       },
     },
@@ -121,12 +121,13 @@ export function ComboAnalysisChart(props: Props) {
     },
     toolbox: {
       show: true,
+      left: 0,
+      itemSize: 20,
       feature: {
         saveAsImage: { show: true },
       },
     },
     grid: {
-      left: "3%",
       right: "4%",
       bottom: "3%",
       containLabel: true,

--- a/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
+++ b/frontend/src/components/Analysis/AnalysisReport/FineGrainedAnalysis/MetricPane.tsx
@@ -9,6 +9,7 @@ import { backendClient, parseBackendError } from "../../../../clients";
 import { compareBucketOfCases, hasDuplicate } from "../../utils";
 import { PageState } from "../../../../utils";
 import { ComboAnalysisChart } from "./ComboAnalysisChart";
+import { useWindowSize } from "../../../useWindowSize";
 
 interface Props {
   task: string;
@@ -46,6 +47,7 @@ export function MetricPane(props: Props) {
 
   const [pageState, setPageState] = useState(PageState.success);
   const [selectedBar, setSelectedBar] = useState<BarInfo>();
+  const [windowWidth] = useWindowSize();
 
   // ExampleTable
   // cases to show for each system; numSystem x numCases
@@ -75,10 +77,15 @@ export function MetricPane(props: Props) {
     );
     if (
       maxRightBoundsLength > 5 ||
-      (systems.length > 1 && maxRightBoundsLength > 3)
+      (systems.length > 1 && maxRightBoundsLength > 3) ||
+      windowWidth < 500
     ) {
       return 24;
-    } else if (maxRightBoundsLength > 3 || systems.length > 1) {
+    } else if (
+      maxRightBoundsLength > 3 ||
+      systems.length > 1 ||
+      windowWidth < 1200
+    ) {
       return 12;
     } else {
       return 8;

--- a/frontend/src/components/Analysis/BarChart/index.tsx
+++ b/frontend/src/components/Analysis/BarChart/index.tsx
@@ -176,13 +176,14 @@ export function BarChart(props: Props) {
       text: title,
       left: "center",
       textStyle: {
-        width: "250",
+        width: "180",
         overflow: "break",
       },
     },
     legend: legend,
     toolbox: {
       itemSize: 20,
+      left: 0,
       show: true,
       feature: {
         saveAsImage: { show: true },

--- a/frontend/src/components/useWindowSize.tsx
+++ b/frontend/src/components/useWindowSize.tsx
@@ -1,0 +1,14 @@
+import { useState, useLayoutEffect } from "react";
+
+export const useWindowSize = (): number[] => {
+  const [windowSize, setWindowSize] = useState([0, 0]);
+  const updateWindowSize = () => {
+    setWindowSize([window.innerWidth, window.innerHeight]);
+  };
+  useLayoutEffect(() => {
+    window.addEventListener("resize", updateWindowSize);
+    updateWindowSize();
+    return () => window.removeEventListener("resize", updateWindowSize);
+  }, []);
+  return [windowSize[0], windowSize[1]];
+};


### PR DESCRIPTION
Part of Issue #546 

- Moved the toolbox to the left and reduced title length so that they do not overlap (see below)
- Now the analyses chart layout changes adaptively according to window size. For example, if window is too small, we display only two charts instead of three on each row.

![image](https://user-images.githubusercontent.com/33018020/206101999-94c37c24-bba5-4f98-ab66-9819eef6e6d2.png)

