### PR TITLE
Fixes error when name is prefix

### DIFF
--- a/backend/src/impl/db_utils/benchmark_db_utils.py
+++ b/backend/src/impl/db_utils/benchmark_db_utils.py
@@ -203,7 +203,9 @@ class BenchmarkDBUtils:
         dataset_metadatas: list[DatasetMetadata] = []
         for x in dataset_configs:
             dataset_return = DatasetDBUtils.find_datasets(
-                dataset_name=x["dataset_name"], sub_dataset=x.get("sub_dataset", None)
+                dataset_name=x["dataset_name"],
+                sub_dataset=x.get("sub_dataset", None),
+                strict_name_match=True,
             )
             if dataset_return.total != 1:
                 raise ValueError(

--- a/backend/src/impl/db_utils/dataset_db_utils.py
+++ b/backend/src/impl/db_utils/dataset_db_utils.py
@@ -105,6 +105,7 @@ class DatasetDBUtils:
         sub_dataset: str | None = None,
         task: str | None = None,
         no_limit: bool = False,
+        strict_name_match: bool = False,
     ) -> DatasetsReturn:
         my_db = DatasetDBUtils.get_dataset_db()
         metadata_ids: set[int] | None = None
@@ -115,6 +116,8 @@ class DatasetDBUtils:
                     metadata_ids.add(my_db.id_dict[dataset_id])
         if dataset_name is not None:
             found_items = my_db.name_trie.keys(dataset_name)
+            if strict_name_match:
+                found_items = [x for x in found_items if x == dataset_name]
             found_ids = [my_db.name_dict[x] for x in found_items]
             chained_ids = list(itertools.chain.from_iterable(found_ids))
             metadata_ids = (


### PR DESCRIPTION
Adds the ability to exactly match dataset names when searching for datasets and applies this to the benchmark functionality.

Fixes https://github.com/neulab/explainaboard_web/issues/571