### PR TITLE
Featured and All Benchmarks

### DIFF
--- a/backend/src/impl/db_utils/benchmark_db_utils.py
+++ b/backend/src/impl/db_utils/benchmark_db_utils.py
@@ -141,9 +141,12 @@ class BenchmarkDBUtils:
             "last_modified"
         ] = datetime.datetime.utcnow()
 
-        config = BenchmarkConfig.from_dict(props_dict)
         BenchmarkDBUtils._convert_id_to_db(props_dict)
         DBUtils.insert_one(DBUtils.BENCHMARK_METADATA, props_dict)
+
+        BenchmarkDBUtils._convert_id_from_db(props_dict)
+        UserDBUtils.insert_preferred_username(props_dict)
+        config = BenchmarkConfig.from_dict(props_dict)
 
         return config
 

--- a/backend/src/impl/db_utils/db_utils.py
+++ b/backend/src/impl/db_utils/db_utils.py
@@ -29,6 +29,9 @@ class DBUtils:
     BENCHMARK_METADATA = DBCollection(
         db_name="metadata", collection_name="benchmark_metadata"
     )
+    BENCHMARK_FEATURED_LIST = DBCollection(
+        db_name="metadata", collection_name="benchmark_featured_list"
+    )
 
     @staticmethod
     def _convert_id(_id: str | ObjectId):

--- a/backend/src/impl/db_utils/user_db_utils.py
+++ b/backend/src/impl/db_utils/user_db_utils.py
@@ -9,6 +9,19 @@ from explainaboard_web.models.user import User
 
 class UserDBUtils:
     @staticmethod
+    def insert_preferred_username(doc: dict) -> None:
+        user = UserDBUtils.find_users([doc["creator"]])[0]
+        doc["preferred_username"] = user.preferred_username
+
+    @staticmethod
+    def insert_preferred_usernames(docs: list[dict]) -> None:
+        user_ids = {doc["creator"] for doc in docs}
+        users = UserDBUtils.find_users(list(user_ids))
+        id_to_preferred_username = {user.id: user.preferred_username for user in users}
+        for doc in docs:
+            doc["preferred_username"] = id_to_preferred_username[doc["creator"]]
+
+    @staticmethod
     def create_user(user: User) -> User:
         doc = user.to_dict()
         doc["_id"] = doc["id"]

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -187,8 +187,13 @@ def metric_descriptions_get() -> dict[str, str]:
 """ /benchmarks """
 
 
-def benchmark_configs_get(parent: str | None) -> list[BenchmarkConfig]:
-    return BenchmarkDBUtils.find_configs(parent)
+def benchmark_configs_get(
+    parent: str | None, featured: bool | None
+) -> list[BenchmarkConfig]:
+    if featured:
+        return BenchmarkDBUtils.find_configs_featured()
+    else:
+        return BenchmarkDBUtils.find_configs(parent)
 
 
 def benchmark_get_by_id(benchmark_id: str, by_creator: bool) -> Benchmark:

--- a/frontend/src/components/BenchmarkCards/index.tsx
+++ b/frontend/src/components/BenchmarkCards/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router-dom";
 import "./index.css";
 import {
   Card,
@@ -10,6 +9,7 @@ import {
   Space,
   Popconfirm,
   Button,
+  Radio,
   message,
 } from "antd";
 import { BenchmarkConfig } from "../../clients/openapi";
@@ -19,15 +19,22 @@ import { BenchmarkSubmitDrawer } from "../BenchmarkSubmitDrawer";
 import { backendClient, parseBackendError } from "../../clients";
 import { DeleteOutlined } from "@ant-design/icons";
 import { useUser } from "../useUser";
+import { FilterUpdate } from "../../pages/BenchmarkPage/BenchmarkFilter";
 
 interface Props {
   items: Array<BenchmarkConfig>;
-  subtitle: string;
+  isAtRootPage: boolean;
+  showFeatured: boolean;
+  onFilterChange: (value: FilterUpdate) => void;
 }
 
-export function BenchmarkCards({ items, subtitle }: Props) {
+export function BenchmarkCards({
+  items,
+  isAtRootPage,
+  showFeatured,
+  onFilterChange,
+}: Props) {
   const { userInfo } = useUser();
-  const history = useHistory();
   const [submitDrawerVisible, setSubmitDrawerVisible] = useState(false);
 
   async function deleteBenchmark(benchmarkID: string) {
@@ -46,17 +53,35 @@ export function BenchmarkCards({ items, subtitle }: Props) {
     setSubmitDrawerVisible(true);
   }
 
+  const featuredVsAllOptions = [
+    { label: "Featured", value: true, disabled: !isAtRootPage },
+    { label: "All", value: false, disabled: !isAtRootPage },
+  ];
+
+  const featuredVsAllBenchmarksToggle = (
+    <Radio.Group
+      options={featuredVsAllOptions}
+      onChange={({ target: { value } }) => {
+        onFilterChange({ showFeatured: value });
+      }}
+      value={showFeatured}
+      optionType="button"
+      buttonStyle="solid"
+    />
+  );
+
   return (
     <div className="page">
       <Helmet>
         <title>ExplainaBoard - Benchmarks</title>
       </Helmet>
       <PageHeader
-        onBack={() => history.push("/")}
+        onBack={() => onFilterChange({ parentId: "" })}
         title="Benchmarks"
-        subTitle={subtitle}
+        subTitle="Select a benchmark"
       />
-      <Row justify="end">
+      <Row justify="space-between" style={{ marginBottom: "10px" }}>
+        <Space>{featuredVsAllBenchmarksToggle}</Space>
         <Space style={{ width: "fit-content", float: "right" }}>
           <NewResourceButton
             onClick={showSubmitDrawer}
@@ -80,9 +105,9 @@ export function BenchmarkCards({ items, subtitle }: Props) {
                     <Typography.Title level={3}>{config.name}</Typography.Title>
                   </div>
                 }
-                onClick={() =>
-                  history.push(`${document.location.pathname}?id=${config.id}`)
-                }
+                onClick={() => {
+                  onFilterChange({ parentId: config.id, showFeatured: false });
+                }}
                 cover={
                   <img
                     alt="example"
@@ -91,6 +116,7 @@ export function BenchmarkCards({ items, subtitle }: Props) {
                   />
                 }
               >
+                <Row>Creator: {config.preferred_username}</Row>
                 <Row justify="end">
                   <Popconfirm
                     disabled={notCreator}

--- a/frontend/src/components/BenchmarkTable/index.tsx
+++ b/frontend/src/components/BenchmarkTable/index.tsx
@@ -20,10 +20,12 @@ import { useHistory, Link } from "react-router-dom";
 import { CheckSquareTwoTone } from "@ant-design/icons";
 import { Plot } from "../../components";
 import { Helmet } from "react-helmet";
+import { FilterUpdate } from "../../pages/BenchmarkPage/BenchmarkFilter";
 
 interface Props {
   /**initial value for task filter */
   benchmarkID: string;
+  onFilterChange: (value: FilterUpdate) => void;
 }
 
 function tableToPage(my_view: BenchmarkTableData) {
@@ -75,7 +77,7 @@ function tableToPage(my_view: BenchmarkTableData) {
 }
 
 /** A table that lists all systems */
-export function BenchmarkTable({ benchmarkID }: Props) {
+export function BenchmarkTable({ benchmarkID, onFilterChange }: Props) {
   const [benchmark, setBenchmark] = useState<Benchmark>();
   const [pageState, setPageState] = useState(PageState.loading);
   const [byCreator, setByCreator] = useState<boolean>(false);
@@ -161,6 +163,10 @@ export function BenchmarkTable({ benchmarkID }: Props) {
           <Helmet>
             <title>ExplainaBoard - {benchmark.config.name} Benchmark</title>
           </Helmet>
+          <PageHeader
+            title={<b style={{ fontSize: "30px" }}>{benchmarkID} Benchmark</b>}
+            onBack={() => onFilterChange({ parentId: "" })}
+          />
           <Descriptions
             title={<b style={{ fontSize: "30px" }}>{benchmark.config.name}</b>}
           >

--- a/frontend/src/pages/BenchmarkPage/BenchmarkFilter.ts
+++ b/frontend/src/pages/BenchmarkPage/BenchmarkFilter.ts
@@ -1,0 +1,60 @@
+export const filterKeyMap = {
+  parentId: "parent_id",
+  showFeatured: "show_featured",
+};
+
+export type FilterUpdate = Partial<BenchmarkFilter>;
+type QueryDict = { [key: string]: string };
+
+export class BenchmarkFilter {
+  parentId: string | undefined;
+  showFeatured: boolean;
+
+  constructor(partial: FilterUpdate) {
+    Object.assign(this, partial);
+    this.showFeatured =
+      partial.showFeatured === undefined ? true : partial.showFeatured;
+  }
+
+  update(filterUpdate: FilterUpdate): BenchmarkFilter {
+    const filterValues = { ...this, ...filterUpdate };
+    return new BenchmarkFilter(filterValues);
+  }
+
+  toUrlParams(): URLSearchParams {
+    const queryParams = new URLSearchParams();
+    for (const [key, val] of Object.entries(
+      BenchmarkFilter.parseFilterToQuery(this)
+    )) {
+      queryParams.append(key, val);
+    }
+    return queryParams;
+  }
+
+  static parseQueryToFilter(query: URLSearchParams): BenchmarkFilter {
+    const filters: FilterUpdate = {};
+
+    const parentId = query.get(filterKeyMap.parentId);
+    filters.parentId = parentId || "";
+
+    const showFeatured = query.get(filterKeyMap.showFeatured);
+    if (filters.parentId === "") {
+      filters.showFeatured = showFeatured === "false" ? false : true;
+    } else {
+      // featured benchmarks are only available at
+      // the root page, so we set the filter to false here
+      filters.showFeatured = false;
+    }
+
+    return new BenchmarkFilter(filters);
+  }
+
+  static parseFilterToQuery(filter: Partial<BenchmarkFilter>): QueryDict {
+    const dict: QueryDict = {};
+
+    dict[filterKeyMap.parentId] = filter.parentId || "";
+    dict[filterKeyMap.showFeatured] = filter.showFeatured ? "true" : "false";
+
+    return dict;
+  }
+}

--- a/frontend/src/pages/BenchmarkPage/index.tsx
+++ b/frontend/src/pages/BenchmarkPage/index.tsx
@@ -36,9 +36,9 @@ export function BenchmarkPage() {
     const newString = filters.toUrlParams().toString();
     if (prevString !== newString) {
       history.replace({ search: filters.toUrlParams().toString() });
+    } else {
+      fetchItems();
     }
-
-    fetchItems();
   }, [history, filters, query, id]);
 
   if (isAtRootPage || items.length !== 0) {

--- a/frontend/src/pages/BenchmarkPage/index.tsx
+++ b/frontend/src/pages/BenchmarkPage/index.tsx
@@ -7,29 +7,54 @@ import { backendClient } from "../../clients";
 import { BenchmarkConfig } from "../../clients/openapi";
 import { useGoogleAnalytics } from "../../components/useGoogleAnalytics";
 import useQuery from "../../components/useQuery";
+import { BenchmarkFilter, FilterUpdate } from "./BenchmarkFilter";
 
 export function BenchmarkPage() {
   useGoogleAnalytics();
   const history = useHistory();
   const query = useQuery();
-  const id = query.get("id") || "";
 
   const [items, setItems] = useState<BenchmarkConfig[]>([]);
+  const [filters, setFilters] = useState<BenchmarkFilter>(
+    BenchmarkFilter.parseQueryToFilter(query)
+  );
+
+  const id = filters.parentId || "";
+  const isAtRootPage = id === "";
+
+  const onFilterChange = function (updates: FilterUpdate) {
+    setFilters(filters.update(updates));
+  };
 
   useEffect(() => {
     async function fetchItems() {
-      setItems(await backendClient.benchmarkConfigsGet(id));
+      setItems(
+        await backendClient.benchmarkConfigsGet(id, filters.showFeatured)
+      );
     }
-    fetchItems();
-  }, [id, history]);
+    const prevString = query.toString();
+    const newString = filters.toUrlParams().toString();
+    if (prevString !== newString) {
+      history.replace({ search: filters.toUrlParams().toString() });
+    }
 
-  if (id === "" || items.length !== 0) {
-    return <BenchmarkCards items={items} subtitle="Select a benchmark" />;
+    fetchItems();
+  }, [history, filters, query, id]);
+
+  if (isAtRootPage || items.length !== 0) {
+    return (
+      <BenchmarkCards
+        items={items}
+        isAtRootPage={isAtRootPage}
+        showFeatured={filters.showFeatured}
+        onFilterChange={onFilterChange}
+      />
+    );
   } else {
     return (
       <div>
         <div style={{ padding: "0 10px" }}>
-          <BenchmarkTable benchmarkID={id} />
+          <BenchmarkTable benchmarkID={id} onFilterChange={onFilterChange} />
         </div>
       </div>
     );

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -89,6 +89,12 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: featured
+          example: true
+          schema:
+            type: boolean
+          required: false
       responses:
         "200":
           description: OK
@@ -1556,7 +1562,9 @@ components:
           properties:
             creator:
               type: string
-          required: [creator]
+            preferred_username:
+              type: string
+          required: [creator, preferred_username]
 
     SignificanceTestInfo:
       type: object

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.24"
+  version: "0.2.25"
   contact:
     email: "explainaboard@gmail.com"
   license:


### PR DESCRIPTION
This PR allows users to toggle between featured and all benchmarks. It also shows the preferred usernames.

Currently, the UI layouts of featured and all benchmarks are still identical, where each benchmark is shown as a card. I was planning to change the layout of all benchmarks to a table (like how systems are displayed) but realized more clarifications are needed. I've put my questions in issue #574 .

### Backend
- Created a new DB collection `benchmark_featured_list` under DB `metadata` to store the list of featured benchmark ids. This allows admins to maintain the list easily and doesn't require redeployment when the list is modified. Since the list is read-only, it might be even better to store it on Cloud Storage. I might need some pointers on how to create it on GCP 🙏
- Added `preferred_usernames` as a required field to `BenchmarkConfig` in `openapi.yaml` and modified related API endpoints.  
<img width="340" alt="Screen Shot 2022-12-31 at 12 01 55 PM" src="https://user-images.githubusercontent.com/30998659/210150645-b91da630-c863-4a3c-be2d-db097361bb23.png">

### Frontend
- Allow users to toggle between featured and all benchmarks. The toggle button is only active at the root page (when parent id == ""), see the last screenshot for an example where the button is inactive.
- Shows preferred usernames.
- Created a filter class to organize `parent_id` and `show_featured` parameters.
- Bound the filter with URL params so users can share a page easily via URL, just like before.

<img width="550" alt="Screen Shot 2022-12-31 at 12 20 50 PM" src="https://user-images.githubusercontent.com/30998659/210151121-5f55549f-75a4-4b9e-a794-757ce5cb77eb.png">

<img width="500" alt="Screen Shot 2022-12-31 at 12 21 42 PM" src="https://user-images.githubusercontent.com/30998659/210151138-ed54ae60-b01d-4e42-a2a5-be79413657e2.png">

<img width="500" alt="Screen Shot 2022-12-31 at 12 58 00 PM" src="https://user-images.githubusercontent.com/30998659/210151948-0ad121eb-d98f-45db-b794-49e732a0b82f.png">

