### PR TITLE
Allow benchmark search by ID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         entry: flake8
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         files: '\.py$'

--- a/backend/src/impl/db_utils/benchmark_db_utils.py
+++ b/backend/src/impl/db_utils/benchmark_db_utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -54,7 +55,7 @@ class BenchmarkDBUtils:
 
     @staticmethod
     def find_configs(
-        parent: str, page: int = 0, page_size: int = 0
+        benchmark: str | None, parent: str | None, page: int = 0, page_size: int = 0
     ) -> list[BenchmarkConfig]:
         permissions_list = [{"is_private": False}]
         user = get_user()
@@ -62,7 +63,13 @@ class BenchmarkDBUtils:
             permissions_list.append({"creator": user.id})
             permissions_list.append({"shared_users": user.email})
 
-        filt = {"$and": [{"parent": parent}, {"$or": permissions_list}]}
+        and_list: list[dict[str, Any]] = [{"$or": permissions_list}]
+        if benchmark:
+            and_list.append({"_id": benchmark})
+        if parent:
+            and_list.append({"parent": parent})
+
+        filt = {"$and": and_list}
         cursor, _ = DBUtils.find(
             DBUtils.BENCHMARK_METADATA, filt=filt, limit=page * page_size
         )

--- a/backend/src/impl/default_controllers_impl.py
+++ b/backend/src/impl/default_controllers_impl.py
@@ -188,12 +188,12 @@ def metric_descriptions_get() -> dict[str, str]:
 
 
 def benchmark_configs_get(
-    parent: str | None, featured: bool | None
+    benchmark: str | None, parent: str | None, featured: bool | None
 ) -> list[BenchmarkConfig]:
     if featured:
         return BenchmarkDBUtils.find_configs_featured()
     else:
-        return BenchmarkDBUtils.find_configs(parent)
+        return BenchmarkDBUtils.find_configs(benchmark=benchmark, parent=parent)
 
 
 def benchmark_get_by_id(benchmark_id: str, by_creator: bool) -> Benchmark:

--- a/frontend/src/pages/BenchmarkPage/index.tsx
+++ b/frontend/src/pages/BenchmarkPage/index.tsx
@@ -29,7 +29,11 @@ export function BenchmarkPage() {
   useEffect(() => {
     async function fetchItems() {
       setItems(
-        await backendClient.benchmarkConfigsGet(id, filters.showFeatured)
+        await backendClient.benchmarkConfigsGet(
+          undefined,
+          id,
+          filters.showFeatured
+        )
       );
     }
     const prevString = query.toString();

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: "ExplainaBoard"
   description: "Backend APIs for ExplainaBoard"
-  version: "0.2.25"
+  version: "0.2.26"
   contact:
     email: "explainaboard@gmail.com"
   license:
@@ -83,6 +83,12 @@ paths:
         - BearerAuth: []
         - {}
       parameters:
+        - in: query
+          name: benchmark_id
+          example: globalbench
+          schema:
+            type: string
+          required: false
         - in: query
           name: parent_id
           example: globalbench


### PR DESCRIPTION
# Description

This PR makes it possible to use the ExplainaBoard API to search for benchmarks by ID.
Previously it was only possible to search for benchmarks by parent.