### PR TITLE
bump explainaboard version: 0.12.5

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 apache-beam~=2.41.0
 boto3~=1.24.68
 en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
-explainaboard == 0.12.4
+explainaboard == 0.12.5
 Flask-PyMongo~=2.3.0
 google-cloud-storage~=2.5.0
 iso-639~=0.4.5


### PR DESCRIPTION
bump explainaboard version: 0.12.5: https://github.com/neulab/ExplainaBoard/pull/608